### PR TITLE
Fix issue with python interpreter subprocess

### DIFF
--- a/underworld3/_jitextension.py
+++ b/underworld3/_jitextension.py
@@ -347,7 +347,8 @@ cpdef PtrContainer getptrobj():
             f.write(strguy)
 
     # Build
-    process = subprocess.Popen('python3 setup.py build_ext --inplace'.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=tmpdir)
+    import sys
+    process = subprocess.Popen(sys.executable + ' setup.py build_ext --inplace'.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=tmpdir)
     process.communicate()
 
     # Load and add to dictionary


### PR DESCRIPTION
OK so that's an ugly bug that I think is the root cause of Haibin's problem on Ubuntu.

The JIT compile module using a subprocess via:

```
subprocess.Popen('python3 setup.py build_ext --inplace'.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=tmpdir)
```

That is a very dangerous way of doing things as it does not ensure that the python interpreter is the same as the one used to start underworld3.
The only way to make sure that we are using the same interpreter is to use `sys.executable`

```
subprocess.Popen([sys.executable] + 'setup.py build_ext --inplace'.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=tmpdir)
```

I found out about this because Haibin's default python is 3.5 but he calls explicitly python3.9.
Virtual environments seem a bit more forgiven but I have seen cases where the JIT was calling the Cython module outside my virtual environment... 