### PR TITLE
Pop control implementation

### DIFF
--- a/Jupyterbook/Notebooks/Developers/Snippets/swarm_popControl_test.py
+++ b/Jupyterbook/Notebooks/Developers/Snippets/swarm_popControl_test.py
@@ -140,7 +140,8 @@ with swarm.access():
 print(f'cell particles min: {s_cID_counts.min()}\ncell particles max: {s_cID_counts.max()}')
 
 # %%
-pop_control.repopulate(material)
+# pop_control.repopulate_loop(material)
+pop_control.repopulate_fast(material)
 with swarm.access():
     s_cID, s_cID_counts = np.unique(swarm.particle_cellid.data, return_counts=True)
 print(f'cell particles min: {s_cID_counts.min()}\ncell particles max: {s_cID_counts.max()}')
@@ -164,7 +165,8 @@ print(f'cell particles min: {s_cID_counts.min()}\ncell particles max: {s_cID_cou
 
 
 # %%
-pop_control.repopulate(material)
+# pop_control.repopulate_loop(material)
+pop_control.repopulate_fast(material)
 plot_mat()
 
 with swarm.access():
@@ -185,7 +187,8 @@ with swarm.access():
 print(f'cell particles min: {s_cID_counts.min()}\ncell particles max: {s_cID_counts.max()}')
 
 # %%
-pop_control.repopulate(material)
+# pop_control.repopulate_loop(material)
+pop_control.repopulate_fast(material)
 plot_mat()
 
 with swarm.access():
@@ -206,7 +209,8 @@ with swarm.access():
 print(f'cell particles min: {s_cID_counts.min()}\ncell particles max: {s_cID_counts.max()}')
 
 # %%
-pop_control.repopulate(material)
+# pop_control.repopulate_loop(material)
+pop_control.repopulate_fast(material)
 plot_mat()
 
 with swarm.access():

--- a/Jupyterbook/Notebooks/Developers/Snippets/swarm_popControl_test.py
+++ b/Jupyterbook/Notebooks/Developers/Snippets/swarm_popControl_test.py
@@ -1,0 +1,224 @@
+# %% [markdown]
+# # Population control test
+
+# %%
+from petsc4py import PETSc
+import underworld3 as uw
+import numpy as np
+import sympy
+from mpi4py import MPI
+
+import os
+
+from underworld3.utilities import generateXdmf, swarm_h5, swarm_xdmf
+import petsc4py
+
+# %%
+petsc4py.__version__
+
+# %%
+petsc4py.get_config()
+
+# %% [markdown]
+# ### Create mesh
+
+# %%
+# mesh = uw.meshing.UnstructuredSimplexBox(minCoords=(0.0,0.0), 
+#                                               maxCoords=(1.0,1.0), 
+#                                               cellSize=1.0/res, 
+#                                               regular=True)
+
+# mesh = uw.meshing.UnstructuredSimplexBox(minCoords=(xmin, ymin), maxCoords=(xmax, ymax), cellSize=1.0 / res, regular=False)
+
+
+mesh = uw.meshing.StructuredQuadBox(elementRes =(int(5),int(5)),
+                                    minCoords=(0,0), 
+                                    maxCoords=(1,1))
+
+
+v = uw.discretisation.MeshVariable('U',    mesh,  mesh.dim, degree=2 )
+
+
+if uw.mpi.rank == 0:
+    print('finished mesh')
+
+
+# %% [markdown]
+# ### Create Stokes object
+
+# %% [markdown]
+# #### Setup swarm
+
+# %%
+swarm     = uw.swarm.Swarm(mesh=mesh)
+
+
+# %%
+# test2      = swarm.add_variable(name="test2", num_components=1, dtype=)
+# test3      = swarm.add_variable(name="test3", num_components=2, dtype=np.float64)
+
+material = swarm.add_variable('M')
+
+swarm.populate_petsc(2)
+pop_control = uw.swarm.PopulationControl(swarm)
+
+if uw.mpi.rank == 0:
+    print('populate swarm')
+
+# %%
+with swarm.access(material):
+    material.data[:,0] = 0 
+    material.data[(swarm.data[:,1] < 0.2) | (swarm.data[:,1] > 0.8) ] = 1
+
+
+# %%
+def plot_mat():
+
+    import numpy as np
+    import pyvista as pv
+    import vtk
+
+    pv.global_theme.background = 'white'
+    pv.global_theme.window_size = [750, 750]
+    pv.global_theme.antialiasing = True
+    pv.global_theme.jupyter_backend = 'panel'
+    pv.global_theme.smooth_shading = True
+
+
+    mesh.vtk("tempMsh.vtk")
+    pvmesh = pv.read("tempMsh.vtk") 
+
+    with swarm.access():
+        points = np.zeros((swarm.data.shape[0],3))
+        points[:,0] = swarm.data[:,0]
+        points[:,1] = swarm.data[:,1]
+        points[:,2] = 0.0
+
+    point_cloud = pv.PolyData(points)
+
+
+    with swarm.access():
+        point_cloud.point_data["M"] = material.data.copy()
+
+
+
+    pl = pv.Plotter(notebook=True)
+
+    pl.add_mesh(pvmesh,'Black', 'wireframe')
+
+    # pl.add_points(point_cloud, color="Black",
+    #                   render_points_as_spheres=False,
+    #                   point_size=2.5, opacity=0.75)       
+
+
+
+    pl.add_mesh(point_cloud, cmap="coolwarm", edge_color="Black", show_edges=False, scalars='M',
+                        use_transparency=False, opacity=0.95, point_size= 20)
+
+
+
+    pl.show(cpos="xy")
+    
+plot_mat()
+
+# %%
+with swarm.access():
+    s_cID, s_cID_counts = np.unique(swarm.particle_cellid.data, return_counts=True)
+print(f'cell particles min: {s_cID_counts.min()}\ncell particles max: {s_cID_counts.max()}')
+
+# %%
+with mesh.access(v):
+    v.data[:,0] = 1
+    
+### Advect particles out to create some empty/under resolved cells
+swarm.advection(V_fn=v.sym, delta_t = 0.2)
+
+plot_mat()
+
+with swarm.access():
+    s_cID, s_cID_counts = np.unique(swarm.particle_cellid.data, return_counts=True)
+print(f'cell particles min: {s_cID_counts.min()}\ncell particles max: {s_cID_counts.max()}')
+
+# %%
+pop_control.repopulate(material)
+with swarm.access():
+    s_cID, s_cID_counts = np.unique(swarm.particle_cellid.data, return_counts=True)
+print(f'cell particles min: {s_cID_counts.min()}\ncell particles max: {s_cID_counts.max()}')
+
+# %%
+plot_mat()
+
+# %%
+
+with mesh.access(v):
+    v.data[:,0] = 1
+    
+### Advect particles out to create some empty/under resolved cells
+swarm.advection(V_fn=v.sym, delta_t = 0.5)
+
+plot_mat()
+
+with swarm.access():
+    s_cID, s_cID_counts = np.unique(swarm.particle_cellid.data, return_counts=True)
+print(f'cell particles min: {s_cID_counts.min()}\ncell particles max: {s_cID_counts.max()}')
+
+
+# %%
+pop_control.repopulate(material)
+plot_mat()
+
+with swarm.access():
+    s_cID, s_cID_counts = np.unique(swarm.particle_cellid.data, return_counts=True)
+print(f'cell particles min: {s_cID_counts.min()}\ncell particles max: {s_cID_counts.max()}')
+
+# %%
+with mesh.access(v):
+    v.data[:,0] = 1
+    
+### Advect particles out to create some empty/under resolved cells
+swarm.advection(V_fn=v.sym, delta_t = 0.5)
+
+plot_mat()
+
+with swarm.access():
+    s_cID, s_cID_counts = np.unique(swarm.particle_cellid.data, return_counts=True)
+print(f'cell particles min: {s_cID_counts.min()}\ncell particles max: {s_cID_counts.max()}')
+
+# %%
+pop_control.repopulate(material)
+plot_mat()
+
+with swarm.access():
+    s_cID, s_cID_counts = np.unique(swarm.particle_cellid.data, return_counts=True)
+print(f'cell particles min: {s_cID_counts.min()}\ncell particles max: {s_cID_counts.max()}')
+
+# %%
+with mesh.access(v):
+    v.data[:,0] = 1
+    
+### Advect particles out to create some empty/under resolved cells
+swarm.advection(V_fn=v.sym, delta_t = 0.22)
+
+plot_mat()
+
+with swarm.access():
+    s_cID, s_cID_counts = np.unique(swarm.particle_cellid.data, return_counts=True)
+print(f'cell particles min: {s_cID_counts.min()}\ncell particles max: {s_cID_counts.max()}')
+
+# %%
+pop_control.repopulate(material)
+plot_mat()
+
+with swarm.access():
+    s_cID, s_cID_counts = np.unique(swarm.particle_cellid.data, return_counts=True)
+print(f'cell particles min: {s_cID_counts.min()}\ncell particles max: {s_cID_counts.max()}')
+
+# %%
+
+# %%
+
+# %%
+
+# %%
+
+# %%

--- a/tests/test_1004_DarcyCartesian.py
+++ b/tests/test_1004_DarcyCartesian.py
@@ -33,6 +33,7 @@ unstructured_quad_box_regular = uw.meshing.UnstructuredSimplexBox(minCoords=(min
 )
 
 
+
 def test_Darcy_boxmesh_noG(mesh):
     print(f"Mesh - Coordinates: {mesh.CoordinateSystem.type}")
 
@@ -127,6 +128,25 @@ def test_Darcy_boxmesh_noG(mesh):
     # ### Compare analytical and numerical solution
     assert np.allclose(pressure_analytic_noG, pressure_interp, atol=1e-2)
 
+### Quads
+meshStructuredQuadBox = uw.meshing.StructuredQuadBox(
+    elementRes=(int(res), int(res)), minCoords=(minX, minY), maxCoords=(maxX, maxY), qdegree=2,
+)
+
+unstructured_quad_box_irregular = uw.meshing.UnstructuredSimplexBox(minCoords=(minX, minY), maxCoords=(maxX, maxY), 
+                                                                    cellSize=1/res, qdegree=2, regular=True)
+
+unstructured_quad_box_regular = uw.meshing.UnstructuredSimplexBox(minCoords=(minX, minY), maxCoords=(maxX, maxY), 
+                                                                    cellSize=1/res, qdegree=2, regular=False)
+
+@pytest.mark.parametrize(
+    "mesh",
+    [
+        meshStructuredQuadBox,
+        unstructured_quad_box_irregular,
+        unstructured_quad_box_regular,
+    ],
+)
 
 def test_Darcy_boxmesh_G(mesh):
     print(f"Mesh - Coordinates: {mesh.CoordinateSystem.type}")
@@ -139,9 +159,6 @@ def test_Darcy_boxmesh_G(mesh):
     # x and y coordinates
     x = mesh.N.x
     y = mesh.N.y
-
-    minX, maxX = 0, 1
-    minY, maxY = 0, 1
 
     # #### Set up the Darcy solver
     darcy = uw.systems.SteadyStateDarcy(mesh, p_soln, v_soln)
@@ -161,6 +178,7 @@ def test_Darcy_boxmesh_G(mesh):
 
     interfaceY = -0.25
 
+
     k1 = 1.0
     k2 = 1.0e-4
 
@@ -172,7 +190,9 @@ def test_Darcy_boxmesh_G(mesh):
 
     darcy.constitutive_model.Parameters.diffusivity=kFunc
 
-    ### add bodyforce term
+
+    darcy.f = 0.0
+
     darcy.s = sympy.Matrix([0, -1]).T
 
 
@@ -186,7 +206,6 @@ def test_Darcy_boxmesh_G(mesh):
     darcy._v_projector.smoothing = 1.0e-6
     darcy._v_projector.add_dirichlet_bc(0.0, "Left",  [0])
     darcy._v_projector.add_dirichlet_bc(0.0, "Right", [0])
-# -
 
     # Solve darcy
     darcy.solve()
@@ -222,5 +241,6 @@ def test_Darcy_boxmesh_G(mesh):
 
     # ### Compare analytical and numerical solution
     assert np.allclose(pressure_analytic, pressure_interp, atol=1e-2)
+
 
 

--- a/underworld3/swarm.py
+++ b/underworld3/swarm.py
@@ -733,12 +733,12 @@ class PopulationControl(uw_object):
             ### total number of particles
             self._particleNumber   = self._swarm.data.shape[0]
             ### get the cell IDs from the initial layout
-            self._mesh_cID        = np.unique(self._swarm_cellid)
+            self._mesh_cID, self._cIDcount  = np.unique(self._swarm_cellid, return_counts=True)
             ### particles per cell (need to check this is consistent)
-            self._swarm_ppc        = int(self._particleNumber / self._mesh_cID.shape[0])
+            self._swarm_ppc                  = self._cIDcount[0] #int(self._particleNumber / self._mesh_cID.shape[0])
 
     ### This way is quick and easy but isn't as good at distributing particles
-    def repopulate_fast(self, updateField=None):
+    def repopulate(self, updateField=None):
         """
         This method repopulates the swarm.
         It determined the number of particles lost and uses the original particles that are furtherest from the present location to repopulate the swarm.
@@ -758,127 +758,214 @@ class PopulationControl(uw_object):
         ### get the current swarm positions in the cell
         with self._swarm.access():
             current_swarm_coords = self._swarm.data
+            current_swarm_cells = self._swarm.particle_cellid.data
 
         ### compare distance between the original particles and the current layout
-        ### Do we want to use this method to calculate distances ???
         point_distance = distance.cdist(original_swarm_coords, current_swarm_coords, 'euclidean')
         ### sort the distances from largest to smallest
-
         ### only add the required number of particles to match the initial ppc
         particles_to_add = original_swarm_coords[np.min(point_distance, axis=1).argsort()[::-1]][:num_of_particles_to_add]
 
-  
-        if len(particles_to_add) > 0 :
-            ### do interp before adding particles, otherwise interp happens from the newly added particles
-            if self._updateField != None:
-                ### defualt to the nnn value
-                new_particle_mat = np.rint( self._updateField.rbf_interpolate(particles_to_add) )#, nnn=self._swarm_ppc))
-            
-            ### add the particles
-            ###TODO Fix up the adding of particles (not sure if this is the correct way) 
-            self._swarm.add_particles_with_coordinates(particles_to_add)
+        new_cells = self._swarm.mesh.get_closest_local_cells(particles_to_add)
+        
+        if isinstance(new_cells, int):
+            new_cells = np.array([new_cells])
 
-            if self._updateField != None:
-                with self._swarm.access(self._updateField):
-                    self._updateField.data[ -len(particles_to_add): ] = new_particle_mat
+        # Ensure that 'valid' has the same length as 'particles_to_add'
+        if len(particles_to_add) != len(new_cells):
+            new_cells = np.resize(new_cells, len(particles_to_add))
+
+        valid = new_cells != -1
+
+        valid_coords = particles_to_add[valid]
+        valid_cells = new_cells[valid]
+
+        all_local_coords = np.vstack([current_swarm_coords, valid_coords])
+
+        all_local_cells = np.hstack([current_swarm_cells[:,0], valid_cells])
+
+        ### do interp before adding particles, otherwise interp happens from the newly added particles
+        if (self._updateField != None):
+            ### defualt to the nnn value
+            new_particle_mat = np.rint( self._updateField.rbf_interpolate(all_local_coords) )#, nnn=self._swarm_ppc))
+        
+        swarm_new_size = all_local_coords.data.shape[0]
+
+        self._swarm.dm.addNPoints(swarm_new_size - current_swarm_coords.shape[0])
+
+        cellid = self._swarm.dm.getField("DMSwarm_cellid")
+        coords = self._swarm.dm.getField("DMSwarmPIC_coor").reshape((-1, self._swarm.dim))
+
+        coords[...] = all_local_coords[...]
+        cellid[:]   = all_local_cells[:]
+
+        self._swarm.dm.restoreField("DMSwarmPIC_coor")
+        self._swarm.dm.restoreField("DMSwarm_cellid")
+
+        if (self._updateField != None):
+            with self._swarm.access(self._updateField):
+                self._updateField.data[:,0] = new_particle_mat[:,0]
+
+        uw.mpi.barrier()
+
+        return
 
 
 ## This way seems to give a better distribution of particles
-    def repopulate_loop(self, updateField=None):
+    def redistribute(self, updateField=None):
         """
-        This method repopulates the swarm.
+        This method repopulates the swarm and maintains a well-distributed swarm, deleting and adding particles where required.
         It identifies which cells have lost particles and repopulates them with particles from the original layout.
         It does delete/add particles from/to cells that have gained/lost particles.
-        pass through swarm field that needs to be updated (e.g. the material field)
+        Takes the swarm field that needs to be updated (e.g. the material field)
         """
 
         self._updateField = updateField
+        
+        ### get the original particle positions in the cell
+        original_swarm_coords    = self._swarm_coords
 
-        ### build a kdtree for the swarm at the present layout
-        kd = uw.kdtree.KDTree(np.ascontiguousarray(self._swarm.mesh._centroids))
-        kd.build_index()
-    
+        ### get the current swarm positions in the cell
         with self._swarm.access():
-            n0, d0, b0 = kd.find_closest_point(self._swarm.data)
+            current_swarm_coords = self._swarm.data
+            current_swarm_cells = self._swarm.particle_cellid.data[:,0]
 
-        s_cID, s_cID_c = np.unique(n0, return_counts=True)
+        current_particle_cellID, current_ppc  = np.unique(current_swarm_cells, return_counts=True)
+
+
+        ### find cells that are empty
+        empty_cells = self._mesh_cID[np.isin(self._mesh_cID, current_particle_cellID, invert=True)]
+
+        ### get the coords from the original swarm layout
+        empty_cell_coords = original_swarm_coords[np.isin(self._swarm_cellid,  empty_cells)]
+
+        ### find under-populated cells
+        underpopulated_cells = current_particle_cellID[current_ppc < self._swarm_ppc]
+
+        ### number of particles missing from each cell
+        underpopulated_cell_coords = []
+
+        for cell in underpopulated_cells:
+            ### get the current number of particles in the cell
+            current_particles = current_ppc[current_particle_cellID == cell][0]
+            ### get the number of particles to add
+            no_particles_to_add = self._swarm_ppc - current_particles
+
+            original_cell_coords = original_swarm_coords[self._swarm_cellid == cell]
+            current_cell_coords  = current_swarm_coords[current_swarm_cells == cell]
+
+            ### caculate the distances between the original and current particle positions
+            point_distance = distance.cdist(original_cell_coords, current_cell_coords, 'euclidean')
+            ### add the ones with the largest distance
+            underpopulated_cell_coords.append(original_cell_coords[np.min(point_distance, axis=1).argsort()[::-1]][:no_particles_to_add])
+ 
+
+        if underpopulated_cell_coords:  # Check if the list is not empty
+            underpopulated_cell_coords = np.concatenate(underpopulated_cell_coords)
+        else:
+            underpopulated_cell_coords = np.empty(shape=(0,2))  # Create an empty numpy array
+
+
+        ### Combination of the empty cells and the underpopulated cells
+        particles_to_add = np.vstack([underpopulated_cell_coords, empty_cell_coords])
+
+
+        uw.mpi.barrier()
+
+        new_cells = self._swarm.mesh.get_closest_local_cells(particles_to_add)
         
-        particles_to_add = []
-        particles_to_delete = []
+        if isinstance(new_cells, int):
+            new_cells = np.array([new_cells])
+
+        # Ensure that 'valid' has the same length as 'particles_to_add'
+        if len(particles_to_add) != len(new_cells):
+            new_cells = np.resize(new_cells, len(particles_to_add))
+
+        valid = new_cells != -1
+
+        valid_coords = particles_to_add[valid]
+        valid_cells = new_cells[valid]
+
+        all_local_coords = np.vstack([current_swarm_coords, valid_coords])
+
+        all_local_cells = np.hstack([current_swarm_cells, valid_cells])
+
+        ### do interp before adding particles, otherwise interp happens from the newly added particles
+        if (self._updateField != None):
+            ### defualt to the nnn value
+            new_particle_mat = np.rint( self._updateField.rbf_interpolate(all_local_coords) )#, nnn=self._swarm_ppc))
         
-        ### checks each cellID in the mesh for the number of particles in each cell
-        for id in self._mesh_cID:
-            ### check if swarm cell ID is in mesh cell ID (if false, means the cell has no particles)
-            cellID_check = np.isin(id, s_cID)
-            
-            if cellID_check == False:
-                ### repopulate entire cell
-                count = 0
-                num_of_particles_to_add = (self._swarm_ppc - count)
-                #### repopulate entire cell using the original layout
-                particles_to_add.append( self._swarm_coords[(self._swarm_cellid == id)] )
-            
-            if cellID_check == True:
-                count = s_cID_c[s_cID == id][0]
-                if count < self._swarm_ppc:
+        swarm_new_size = all_local_coords.data.shape[0]
+
+        self._swarm.dm.addNPoints(swarm_new_size - current_swarm_coords.shape[0])
+
+        cellid = self._swarm.dm.getField("DMSwarm_cellid")
+        coords = self._swarm.dm.getField("DMSwarmPIC_coor").reshape((-1, self._swarm.dim))
+
+        coords[...] = all_local_coords[...]
+        cellid[:]   = all_local_cells[:]
+
+        self._swarm.dm.restoreField("DMSwarmPIC_coor")
+        self._swarm.dm.restoreField("DMSwarm_cellid")
+
+        if (self._updateField != None):
+            with self._swarm.access(self._updateField):
+                self._updateField.data[:,0] = new_particle_mat[:,0]
+
+        uw.mpi.barrier()
+
+
+        ### get the current swarm positions in the cell
+        with self._swarm.access():
+            current_swarm_coords = self._swarm.data
+            current_swarm_cells = self._swarm.particle_cellid.data[:,0]
+
+        current_particle_cellID, current_ppc  = np.unique(current_swarm_cells, return_counts=True)
+
+        ### find over-populated cells
+        overpopulated_cells = current_particle_cellID[current_ppc > self._swarm_ppc]
+
+        overpopulated_cell_coords = []
+
+        for cell in overpopulated_cells:
+            ### get the current particles in the cell
+            current_particles = current_ppc[current_particle_cellID == cell][0]
+            ### number of particles to delete
+            no_particles_to_remove = current_particles - self._swarm_ppc
+            ### randomly select particles to remove from the current cell
+            rng = np.random.default_rng()
+
+            #### Selection of coords doesn't delete all particles (?)
+            current_cell_coords  = current_swarm_coords[current_swarm_cells == cell]
+            overpopulated_cell_coords.append(rng.choice(current_cell_coords, no_particles_to_remove))
+
+
+        if overpopulated_cell_coords:  # Check if the list is not empty
+            particles_to_remove = np.concatenate(overpopulated_cell_coords)
+        else:
+            particles_to_remove = np.empty(shape=(0,2))  # Create an empty numpy array
+
+        # Check if all_current_coords and particles_to_remove are not empty
+        with self._swarm.access(self._swarm.particle_coordinates):
+            ### get current coords
+            all_current_coords = self._swarm.data
+
+            if particles_to_remove.size > 0:
+                ### get number of particles to remove
+                no_particles_to_remove = particles_to_remove.shape[0]
+
                     
-                    #### add n number of particles
-                    num_of_particles_to_add = (self._swarm_ppc - count)
+                # Calculate point_distance
+                point_distance = distance.cdist(all_current_coords, particles_to_remove, 'euclidean')
 
-                    ### get the original particle positions in the cell
-                    original_swarm_coords    = self._swarm_coords[(self._swarm_cellid == id)]
-                    ### get the current swarm positions in the cell
-                    with self._swarm.access():
-                        current_swarm_coords = self._swarm.data[(self._swarm.particle_cellid.data[:,0] == id)]
+                # Get the index of particles to remove
+                index_condition = np.min(point_distance, axis=1).argsort()[:no_particles_to_remove]
 
-                    ### compare distance between the original particles and the current layout
-                    point_distance = distance.cdist(original_swarm_coords, current_swarm_coords, 'euclidean')
+                # Set coords to 1.0e100 so they are deleted by the DM, following the same logic as the remeshing example
+                self._swarm.data[index_condition] = 1.0e100
 
-                    #### original version
-                    # particles_to_add.append(self._swarm.mesh._centroids[id]+((np.random.rand(num_of_particles_to_add,2)*2)-1)*self._swarm.mesh.get_min_radius()) 
 
-                    ### get the minimum distance between original and current coords
-                    ### sort the coords from largest distance to smallest
-                    ### only add the number of particles to get us to the required number of particles for the cell
-                    particles_to_add.append(original_swarm_coords[np.min(point_distance, axis=1).argsort()[::-1]][:num_of_particles_to_add])
-                    
-                if count == self._swarm_ppc:
-                    pass
-
-                if count > self._swarm_ppc:
-                    ### remove n number of particles, randomly selected
-                    ####TODO How do we want to select the particles to delete?
-                    num_of_particles_to_remove = (count-self._swarm_ppc)
-                        
-                    rng = np.random.default_rng()
-        
-                    self._swarm.dm.sortGetAccess()
-                    
-                    swarmindex = self._swarm.dm.sortGetPointsPerCell(id)
-        
-                    particles_to_delete.append(rng.choice(swarmindex, num_of_particles_to_remove, replace=False))
-        
-                    self._swarm.dm.sortRestoreAccess()
-       
-        if len(particles_to_add) > 0 :
-            particles_to_add = np.concatenate(particles_to_add)
-            ### do interp before adding particles, otherwise interp happens from the newly added particles (which are assigned a default value)
-            if self._updateField != None:
-                new_particle_mat = np.rint( self._updateField.rbf_interpolate(particles_to_add) ) #, nnn=self._swarm_ppc))
-            
-            ### add the particles
-            ###TODO Fix up the adding of particles (not sure if this is the correct way) 
-            self._swarm.add_particles_with_coordinates(particles_to_add)
-
-            if self._updateField != None:
-                with self._swarm.access(self._updateField):
-                    self._updateField.data[ -len(particles_to_add): ] = new_particle_mat
-        ### delete particles from over-populated cells
-        ###TODO is this the correct way?
-        if len(particles_to_delete) > 0 :
-            particles_to_delete = np.concatenate(particles_to_delete)
-            for i in particles_to_delete:
-                self._swarm.dm.removePointAtIndex(i)
+        return
 
 
 
@@ -2041,6 +2128,238 @@ class NodalPointSwarm(Swarm):
 
         return
 
+class Eulerian_D_Dt(uw_object):
+    r"""Eulerian  (mesh based) History Manager:
+    This manages the update of a variable, $\psi$ on the mesh across timesteps.
+    $$\quad \psi_p^{t-n\Delta t} \leftarrow \psi_p^{t-(n-1)\Delta t}\quad$$
+    $$\quad \psi_p^{t-(n-1)\Delta t} \leftarrow \psi_p^{t-(n-2)\Delta t} \cdots\quad$$
+    $$\quad \psi_p^{t-\Delta t} \leftarrow \psi_p^{t}$$
+    """
+
+    @timing.routine_timer_decorator
+    def __init__(
+        self,
+        mesh: uw.discretisation.Mesh,
+        psi_fn: sympy.Function,
+        vtype: uw.VarType,
+        degree: int,
+        continuous: bool,
+        varsymbol: Optional[str] = r"u",
+        verbose: Optional[bool] = False,
+        bcs=[],
+        order=1,
+        smoothing=0.0,
+    ):
+        super().__init__()
+
+        self.mesh = mesh
+        self.bcs = bcs
+        self.verbose = verbose
+        self.degree = degree
+
+        # meshVariables are required for:
+        #
+        # u(t) - evaluation of u_fn at the current time
+        # u*(t) - u_* evaluated from
+
+        # psi is evaluated/stored at `order` timesteps. We can't
+        # be sure if psi is a meshVariable or a function to be evaluated
+        # psi_star is reaching back through each evaluation and has to be a
+        # meshVariable (storage)
+
+        self._psi_fn = psi_fn
+        self.order = order
+
+        psi_star = []
+        self.psi_star = psi_star
+
+        for i in range(order):
+            self.psi_star.append(
+                uw.discretisation.MeshVariable(
+                    f"psi_star_sl_{self.instance_number}_{i}",
+                    self.mesh,
+                    vtype=vtype,
+                    degree=degree,
+                    continuous=continuous,
+                    varsymbol=rf"{varsymbol}^{{ {'*'*(i+1)} }}",
+                )
+            )
+
+
+        # The projection operator for mapping swarm values to the mesh - needs to be different for
+        # each variable type, unfortunately ...
+        ### using this to store the flux term
+
+        if vtype == uw.VarType.SCALAR:
+            self._psi_star_projection_solver = uw.systems.solvers.SNES_Projection(
+                self.mesh, self.psi_star[0], verbose=False
+            )
+        elif vtype == uw.VarType.VECTOR:
+            self._psi_star_projection_solver = (
+                uw.systems.solvers.SNES_Vector_Projection(
+                    self.mesh, self.psi_star[0], verbose=False
+                )
+            )
+        elif vtype == uw.VarType.SYM_TENSOR or vtype == uw.VarType.TENSOR:
+            self._WorkVar = uw.discretisation.MeshVariable(
+                f"W_star_slcn_{self.instance_number}",
+                self.mesh,
+                vtype=uw.VarType.SCALAR,
+                degree=degree,
+                continuous=continuous,
+                varsymbol=r"W^{*}",
+            )
+            self._psi_star_projection_solver = (
+                uw.systems.solvers.SNES_Tensor_Projection(
+                    self.mesh, self.psi_star[0], self._WorkVar, verbose=False
+                )
+            )
+
+        self._psi_star_projection_solver.uw_function = self.psi_fn
+        self._psi_star_projection_solver.bcs = bcs
+        self._psi_star_projection_solver.smoothing = smoothing
+
+        
+        ### solve to get initial values
+        self._psi_star_projection_solver.solve()
+
+        ### set up all history terms to the initial values
+        for i in range(self.order - 1, 0, -1):
+            with self.mesh.access(self.psi_star[i]):
+                self.psi_star[i].data[...] = self.psi_star[0].data[...]
+
+        
+        ### set the default values to the initial condition
+        ### Doesn't work for flux terms due to containing derivatives
+        # for i in range(self.order):
+        #     with self.mesh.access(self.psi_star[i]):
+        #         for d in range(self.psi_star[i].shape[1]):
+        #             self.psi_star[i].data[:, d] = uw.function.evalf(
+        #                          self._psi_fn[d], self.psi_star[i].coords
+        #                         )
+    
+
+        return
+
+    @property
+    def psi_fn(self):
+        return self._psi_fn
+
+    @psi_fn.setter
+    def psi_fn(self, new_fn):
+        self._psi_fn = new_fn
+        self._psi_star_projection_solver.uw_function = self._psi_fn
+        return
+
+    def _object_viewer(self):
+        from IPython.display import Latex, Markdown, display
+
+        super()._object_viewer()
+
+        ## feedback on this instance
+        # display(Latex(r"$\quad\psi = $ " + self.psi._repr_latex_()))
+        # display(
+        #     Latex(
+        #         r"$\quad\Delta t_{\textrm{phys}} = $ "
+        #         + sympy.sympify(self.dt_physical)._repr_latex_()
+        #     )
+        # )
+        display(Latex(rf"$\quad$History steps = {self.order}"))
+
+    def update(
+        self,
+        evalf: Optional[bool] = False,
+        verbose: Optional[bool] = False,
+    ):
+        self.update_pre_solve(evalf, verbose)
+        return
+
+    def update_pre_solve(
+        self,
+        evalf: Optional[bool] = False,
+        verbose: Optional[bool] = False,
+    ):
+        return
+
+    def update_post_solve(
+        self,
+        evalf: Optional[bool] = False,
+        verbose: Optional[bool] = False,
+    ):
+        # if average_over_dt:
+        #     phi = min(1.0, dt / self.dt_physical)
+        # else:
+        #     phi = 1.0
+
+        if verbose and uw.mpi.rank == 0:
+            print(f"Update {self.psi_fn}", flush=True)
+
+
+        ### copy values down the chain
+        for i in range(self.order - 1, 0, -1):
+            with self.mesh.access(self.psi_star[i]):
+                self.psi_star[i].data[...] = self.psi_star[i-1].data[...]
+
+        ### update the first value in the chain
+        self._psi_star_projection_solver.uw_function = self.psi_fn
+        self._psi_star_projection_solver.solve()
+
+        return
+
+    def bdf(self, order=None):
+        r"""Backwards differentiation form for calculating DuDt
+        Note that you will need `bdf` / $\delta t$ in computing derivatives"""
+
+        if order is None:
+            order = self.order
+        else:
+            order = max(1, min(self.order, order))
+
+        with sympy.core.evaluate(False):
+            if order == 1:
+                bdf0 = self.psi_fn - self.psi_star[0].sym
+
+            elif order == 2:
+                bdf0 = (
+                    3 * self.psi_fn / 2
+                    - 2 * self.psi_star[0].sym
+                    + self.psi_star[1].sym / 2
+                )
+
+            elif order == 3:
+                bdf0 = (
+                    11 * self.psi_fn / 6
+                    - 3 * self.psi_star[0].sym
+                    + 3 * self.psi_star[1].sym / 2
+                    - self.psi_star[2].sym / 3
+                )
+
+        return bdf0
+
+    def adams_moulton_flux(self, order=None):
+        if order is None:
+            order = self.order
+        else:
+            order = max(1, min(self.order, order))
+
+        with sympy.core.evaluate(False):
+            if order == 1:
+                am = (self.psi_fn + self.psi_star[0].sym) / 2
+
+            elif order == 2:
+                am = (
+                    5 * self.psi_fn + 8 * self.psi_star[0].sym - self.psi_star[1].sym
+                ) / 12
+
+            elif order == 3:
+                am = (
+                    9 * self.psi_fn
+                    + 19 * self.psi_star[0].sym
+                    - 5 * self.psi_star[1].sym
+                    + self.psi_star[2].sym
+                ) / 24
+
+        return am
 
 class SemiLagrange_D_Dt(uw_object):
     r"""Nodal-Swarm  Lagrangian History Manager:

--- a/underworld3/swarm.py
+++ b/underworld3/swarm.py
@@ -718,6 +718,120 @@ class IndexSwarmVariable(SwarmVariable):
 
         return
 
+class PopulationControl(uw_object):
+    def __init__(self, swarm):
+
+        self._swarm = swarm
+
+        ### copy the original swarm coords and cellids
+        with swarm.access():
+            self._swarm_coords   = np.copy(np.ascontiguousarray( self._swarm.data))
+            self._swarm_cellid   = np.copy(np.ascontiguousarray( self._swarm.particle_cellid.data[:,0]))
+
+        kd = uw.kdtree.KDTree(self._swarm_coords)
+    
+        kd.build_index()
+    
+        ### can be done in init, doesn't change
+        ### get the cell ID
+        self._m_cID = swarm.mesh.get_closest_cells( np.ascontiguousarray(  self._swarm.mesh._centroids) ) 
+
+        ### get the initial ppc
+        with self._swarm.access():
+            s_cID, s_cID_counts = np.unique(self._swarm.particle_cellid.data, return_counts=True)
+            self._swarm_ppc = s_cID_counts[0]
+
+
+    def repopulate(self, updateField=None):
+        """
+        This method repopulates the swarm.
+        pass through field that needs to be updated (e.g. the material field)
+        """
+
+        self._updateField = updateField
+
+        ### build a kdtree for the swarm [Not sure if this can be replaced with something simpler/already implemented]
+        def swarm_kdtree(swarm):
+            kd = uw.kdtree.KDTree(np.ascontiguousarray(swarm.mesh._centroids))
+            kd.build_index()
+        
+            with swarm.access():
+                n, d, b = kd.find_closest_point(swarm.data)
+
+            return n, d, b
+        
+
+        ### needs to be done every loop
+        n0, d0, b0 = swarm_kdtree(self._swarm)
+        s_cID, s_cID_c = np.unique(n0, return_counts=True)
+        
+        particles_to_add = []
+        particles_to_delete = []
+        
+        ### checks each cellID in the mesh for the number of particles in each cell
+        for id in self._m_cID:
+            ### check if swarm cell ID is in mesh cell ID (if false, means the cell has no particles)
+            cellID_check = np.isin(id, s_cID)
+            
+            if cellID_check == False:
+                ### repopulate entire cell
+                count = 0
+                num_of_particles_to_add = (self._swarm_ppc - count)
+                #### repopulate entire cell using the original layout
+                particles_to_add.append( self._swarm_coords[(self._swarm_cellid == id)] )
+            
+            if cellID_check == True:
+                count = s_cID_c[s_cID == id][0]
+                if count < self._swarm_ppc:
+                    
+                    #### add n number of particles
+                    num_of_particles_to_add = (self._swarm_ppc - count)
+
+                    ####TODO How do we want to distribute these particles in cells that are under-populated but not empty?
+
+                    particles_to_add.append(self._swarm.mesh._centroids[id]+((np.random.rand(num_of_particles_to_add,2)*2)-1)*self._swarm.mesh.get_min_radius()) 
+                    
+                if count == self._swarm_ppc:
+                    pass
+
+                if count > self._swarm_ppc:
+                    ### remove n number of particles
+                    ####TODO How do we want to select the particles to delete?
+                    num_of_particles_to_remove = (count-self._swarm_ppc)
+                        
+                    rng = np.random.default_rng()
+        
+                    self._swarm.dm.sortGetAccess()
+                    
+                    swarmindex = self._swarm.dm.sortGetPointsPerCell(id)
+        
+                    particles_to_delete.append(rng.choice(swarmindex, num_of_particles_to_remove, replace=False))
+        
+                    self._swarm.dm.sortRestoreAccess()
+
+        ###TODO Fix up the adding and deleting of particles (not sure if this is correct)         
+        ###TODO how to update the required field(s) ?
+        if len(particles_to_add) > 0 :
+            particles_to_add = np.concatenate(particles_to_add)
+            ### do interp before adding particles, otherwise interp happens from the newly added particles
+            if self._updateField != None:
+                new_particle_mat = np.rint(self._updateField.rbf_interpolate(particles_to_add, nnn=5))
+            
+            ### add the particles
+            self._swarm.add_particles_with_coordinates(particles_to_add)
+
+            if self._updateField != None:
+                with self._swarm.access(self._updateField):
+                    self._updateField.data[ -len(particles_to_add): ] = new_particle_mat
+        ### delete particles from over-populated cells
+        ###TODO how do we want to do this?
+        if len(particles_to_delete) > 0 :
+            particles_to_delete = np.concatenate(particles_to_delete)
+            for i in particles_to_delete:
+                self._swarm.dm.removePointAtIndex(i)
+
+
+
 
 # @typechecked
 class Swarm(Stateful, uw_object):

--- a/underworld3/swarm.py
+++ b/underworld3/swarm.py
@@ -767,15 +767,15 @@ class PopulationControl(uw_object):
         ### only add the required number of particles to match the initial ppc
         particles_to_add = original_swarm_coords[np.min(point_distance, axis=1).argsort()[::-1]][:num_of_particles_to_add]
 
-
-        ###TODO Fix up the adding and deleting of particles (not sure if this is correct)
+  
         if len(particles_to_add) > 0 :
             ### do interp before adding particles, otherwise interp happens from the newly added particles
             if self._updateField != None:
                 ### defualt to the nnn value
-                new_particle_mat = np.rint(self._updateField.rbf_interpolate(particles_to_add))
+                new_particle_mat = np.rint( self._updateField.rbf_interpolate(particles_to_add) )#, nnn=self._swarm_ppc))
             
             ### add the particles
+            ###TODO Fix up the adding of particles (not sure if this is the correct way) 
             self._swarm.add_particles_with_coordinates(particles_to_add)
 
             if self._updateField != None:
@@ -859,22 +859,22 @@ class PopulationControl(uw_object):
                     particles_to_delete.append(rng.choice(swarmindex, num_of_particles_to_remove, replace=False))
         
                     self._swarm.dm.sortRestoreAccess()
-
-        ###TODO Fix up the adding and deleting of particles (not sure if this is correct)         
+       
         if len(particles_to_add) > 0 :
             particles_to_add = np.concatenate(particles_to_add)
             ### do interp before adding particles, otherwise interp happens from the newly added particles (which are assigned a default value)
             if self._updateField != None:
-                new_particle_mat = np.rint(self._updateField.rbf_interpolate(particles_to_add, nnn=5))
+                new_particle_mat = np.rint( self._updateField.rbf_interpolate(particles_to_add) ) #, nnn=self._swarm_ppc))
             
             ### add the particles
+            ###TODO Fix up the adding of particles (not sure if this is the correct way) 
             self._swarm.add_particles_with_coordinates(particles_to_add)
 
             if self._updateField != None:
                 with self._swarm.access(self._updateField):
                     self._updateField.data[ -len(particles_to_add): ] = new_particle_mat
         ### delete particles from over-populated cells
-        ###TODO how do we want to do this?
+        ###TODO is this the correct way?
         if len(particles_to_delete) > 0 :
             particles_to_delete = np.concatenate(particles_to_delete)
             for i in particles_to_delete:


### PR DESCRIPTION
Currently has two different versions. A quick implementation that calculates the distance from the current swarm to the original swarm and adds n particles which are sorted from furtherest to closest distance, where n is the difference between the original swarm and current swarm. A slower implementation that checks the number of particles in each cell, and either adds or deletes particles based on the current ppc. Also uses the initial layout and the distances between the original layout and current layout.

TODO:
- Make sure the addition and deletion of particles is done correctly. 
