### PR TITLE
Trying to fix the solver-then-new-var batman-returns bug. 

### DIFF
--- a/Jupyterbook/Notebooks/Examples-PorousFlow/Ex_Darcy_1D_benchmark.py
+++ b/Jupyterbook/Notebooks/Examples-PorousFlow/Ex_Darcy_1D_benchmark.py
@@ -50,8 +50,6 @@ darcy = uw.systems.SteadyStateDarcy(mesh)
 p_soln = darcy.Unknowns.u
 v_soln = darcy.v
 
-
-
 darcy.petsc_options[
     "snes_rtol"
 ] = 1.0e-6  # Needs to be smaller than the contrast in properties
@@ -82,7 +80,7 @@ kFunc = Piecewise((k1, y >= interfaceY), (k2, y < interfaceY), (1.0, True))
 # kFunc = k2 + (k1-k2) * (0.5 + 0.5 * sympy.tanh(100.0*(y-interfaceY)))
 
 darcy.constitutive_model.Parameters.permeability = kFunc
-darcy.constitutive_model.Parameters.s = sympy.Matrix([0, 0]).T
+darcy.constitutive_model.Parameters.s = -sympy.Matrix([0, 1]).T
 darcy.f = 0.0
 
 # set up boundary conditions

--- a/Jupyterbook/Notebooks/Examples-PorousFlow/Ex_Darcy_1D_benchmark.py
+++ b/Jupyterbook/Notebooks/Examples-PorousFlow/Ex_Darcy_1D_benchmark.py
@@ -39,9 +39,6 @@ mesh = uw.meshing.UnstructuredSimplexBox(
 # x and y coordinates
 x = mesh.N.x
 y = mesh.N.y
-# -
-
-test = uw.systems.SNES_Scalar(mesh)
 
 # +
 # Create Darcy Solver
@@ -56,7 +53,11 @@ darcy.petsc_options[
 
 darcy.constitutive_model = uw.constitutive_models.DarcyFlowModel
 darcy.constitutive_model.Parameters.permeability = 1
+# -
 
+
+p_soln_0 = p_soln.clone("P_no_g", r"{p_\textrm{no g}}")
+v_soln_0 = v_soln.clone("V_no_g", r"{v_\textrm{no g}}")
 
 # +
 # Groundwater pressure boundary condition on the bottom wall
@@ -77,23 +78,32 @@ k2 = 1.0e-4
 kFunc = Piecewise((k1, y >= interfaceY), (k2, y < interfaceY), (1.0, True))
 
 # A smooth version
-# kFunc = k2 + (k1-k2) * (0.5 + 0.5 * sympy.tanh(100.0*(y-interfaceY)))
 
 darcy.constitutive_model.Parameters.permeability = kFunc
-darcy.constitutive_model.Parameters.s = -sympy.Matrix([0, 1]).T
+darcy.constitutive_model.Parameters.s = sympy.Matrix([0, 0]).T
 darcy.f = 0.0
 
 # set up boundary conditions
 darcy.add_dirichlet_bc(0.0, "Top")
 darcy.add_dirichlet_bc(-1.0 * minY * max_pressure, "Bottom")
 
-# # Zero pressure gradient at sides / base (implied bc)
-
-# darcy._v_projector.petsc_options["snes_rtol"] = 1.0e-6
-
 # -
 # Solve time
 darcy.solve()
+with mesh.access(p_soln_0, v_soln_0):
+    p_soln_0.data[...] = p_soln.data[...]
+    v_soln_0.data[...] = v_soln.data[...]
+
+
+# +
+# now switch on gravity
+
+darcy.constitutive_model.Parameters.s = sympy.Matrix([0, -1]).T
+darcy.solve()
+
+# -
+
+
 
 if uw.mpi.size == 1:
 
@@ -151,6 +161,7 @@ xcoords = np.full_like(ycoords, -1)
 xy_coords = np.column_stack([xcoords, ycoords])
 
 pressure_interp = uw.function.evalf(p_soln.sym[0], xy_coords)
+pressure_interp_0 = uw.function.evalf(p_soln_0.sym[0], xy_coords)
 
 
 # +
@@ -188,6 +199,7 @@ import matplotlib.pyplot as plt
 fig = plt.figure()
 ax1 = fig.add_subplot(111, xlabel="Pressure", ylabel="Depth")
 ax1.plot(pressure_interp, ycoords, linewidth=3, label="Numerical solution")
+ax1.plot(pressure_interp_0, ycoords, linewidth=3, label="Numerical solution (no G)")
 ax1.plot(
     pressure_analytic, ycoords, linewidth=3, linestyle="--", label="Analytic solution"
 )

--- a/Jupyterbook/Notebooks/Examples-PostProcessing/Ex_ChannelFlow_Visualise.py
+++ b/Jupyterbook/Notebooks/Examples-PostProcessing/Ex_ChannelFlow_Visualise.py
@@ -1,0 +1,145 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.0
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %%
+# Visualise Channel Flow model 
+
+
+import nest_asyncio
+nest_asyncio.apply()
+import os
+
+import petsc4py
+import underworld3 as uw
+import numpy as np
+import sympy
+
+
+
+
+
+
+# %%
+# ls -trl ../Examples-StokesFlow/output/ChannelFlow3D
+
+# %%
+checkpoint_dir = "../Examples-StokesFlow/output/ChannelFlow3D"
+checkpoint_base = f"WigglyBottom_20"
+meshfile = os.path.join(checkpoint_dir, checkpoint_base) + ".mesh.00000.h5"
+
+step = 0
+
+# %%
+uw.utilities.h5_scan("../Examples-StokesFlow/output/ChannelFlow3D/WigglyBottom_20.mesh.P1.00000.h5")
+
+# %%
+terrain_mesh = uw.discretisation.Mesh(meshfile)
+
+v_soln_ckpt = uw.discretisation.MeshVariable("U1", terrain_mesh, terrain_mesh.dim, degree=2)
+p_soln_ckpt = uw.discretisation.MeshVariable("P1", terrain_mesh, 1, degree=1)
+
+v_soln_ckpt.read_timestep(checkpoint_base, "U1", step, outputPath=checkpoint_dir)
+p_soln_ckpt.read_timestep(checkpoint_base, "P1", step, outputPath=checkpoint_dir)
+
+
+# %%
+## Visualise the mesh
+
+# OR
+# check the mesh if in a notebook / serial
+
+if uw.mpi.size == 1:
+
+    v = v_soln_ckpt
+    p = p_soln_ckpt
+
+    import pyvista as pv
+    import underworld3.visualisation as vis
+
+    pvmesh = vis.mesh_to_pv_mesh(terrain_mesh)
+    pvmesh.point_data["V"] = vis.vector_fn_to_pv_points(pvmesh, v.sym)
+
+    velocity_points = vis.meshVariable_to_pv_cloud(v)
+    velocity_points.point_data["V"] = vis.vector_fn_to_pv_points(velocity_points, v.sym)
+
+    clipped = pvmesh.clip(origin=(0.0, 0.0, -0.09), normal=(0.0, 0, 1), invert=True)
+    clipped.point_data["V"] = vis.vector_fn_to_pv_points(clipped, v.sym)
+
+    clipped2 = pvmesh.clip(origin=(0.0, 0.0, -0.05), normal=(0.0, 0, 1), invert=True)
+    clipped2.point_data["V"] = vis.vector_fn_to_pv_points(clipped2, v.sym)
+    
+    clipped3 = pvmesh.clip(origin=(0.0, 0.0, 0.4), normal=(0.0, 0, 1), invert=False)
+    clipped3.point_data["V"] = vis.vector_fn_to_pv_points(clipped3, v.sym)
+
+
+    skip = 10
+    points = np.zeros((terrain_mesh._centroids[::skip].shape[0], 3))
+    points[:, 0] = terrain_mesh._centroids[::skip, 0]
+    points[:, 1] = terrain_mesh._centroids[::skip, 1]
+    points[:, 2] = terrain_mesh._centroids[::skip, 2]
+
+    point_cloud = pv.PolyData(points[np.logical_and(points[:, 0] < 2.0, points[:, 0] > 0.0)]  )
+
+    pvstream = pvmesh.streamlines_from_source(
+        point_cloud, vectors="V", 
+        integration_direction="forward", 
+        integrator_type=45,
+        surface_streamlines=False,
+        initial_step_length=0.1,
+        max_time=0.5,
+        max_steps=1000
+    )
+
+    point_cloud2 = pv.PolyData(points[np.logical_and(points[:, 2] < 0.5, points[:, 2] > 0.45)]  )
+
+    pvstream2 = pvmesh.streamlines_from_source(
+        point_cloud2, vectors="V", 
+        integration_direction="forward", 
+        integrator_type=45,
+        surface_streamlines=False,
+        initial_step_length=0.01,
+        max_time=0.5,
+        max_steps=1000
+    )
+
+    pl = pv.Plotter(window_size=[1000, 1000])
+    pl.add_axes()
+
+    pl.add_mesh(pvmesh,'Grey', 'wireframe', opacity=0.1)
+    pl.add_mesh(clipped,'Blue', show_edges=False, opacity=0.25)
+    # pl.add_mesh(pvmesh, 'white', show_edges=True, opacity=0.5)
+
+    #pl.add_mesh(pvstream)
+    pl.add_mesh(pvstream2)
+
+
+    arrows = pl.add_arrows(clipped2.points, clipped2.point_data["V"], 
+                           show_scalar_bar = False, opacity=1,
+                           mag=100, )
+    
+    # arrows = pl.add_arrows(clipped3.points, clipped3.point_data["V"], 
+    #                        show_scalar_bar = False, opacity=1,
+    #                        mag=33, )
+
+
+    # pl.screenshot(filename="sphere.png", window_size=(1000, 1000), return_img=False)
+    # OR
+    
+    pl.show(cpos="xy")
+
+
+
+
+# %%

--- a/Jupyterbook/Notebooks/Examples-PostProcessing/Ex_Navier_Stokes_Visualise_NS_DFG_2d.py
+++ b/Jupyterbook/Notebooks/Examples-PostProcessing/Ex_Navier_Stokes_Visualise_NS_DFG_2d.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.15.2
+#       jupytext_version: 1.16.0
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/Jupyterbook/Notebooks/Examples-Utilities/Ex_Stokes_Annulus_Benchmark_Kramer_etal.py
+++ b/Jupyterbook/Notebooks/Examples-Utilities/Ex_Stokes_Annulus_Benchmark_Kramer_etal.py
@@ -1,0 +1,344 @@
+# ## Annulus Benchmark: Isoviscous Incompressible Stokes
+#
+# ### Case: Infinitely thin density anomaly at $r = r'$
+# #### [Benchmark paper](https://gmd.copernicus.org/articles/14/1899/2021/) 
+#
+# *Author: [Thyagarajulu Gollapalli](https://github.com/gthyagi)*
+
+# to fix trame issue
+import nest_asyncio
+nest_asyncio.apply()
+
+# +
+import underworld3 as uw
+from underworld3.systems import Stokes
+
+import numpy as np
+import sympy
+from sympy import lambdify
+import os
+import matplotlib.pyplot as plt
+import cmcrameri.cm as cmc
+import assess
+# -
+
+os.environ["SYMPY_USE_CACHE"] = "no"
+
+if uw.mpi.size == 1:
+    import pyvista as pv
+    import underworld3.visualisation as vis
+
+# mesh options
+res = 1/8
+res_int_fac = 1/2
+r_o = 2.0
+r_int = 1.8
+r_i = 1.0
+
+# +
+# visualize analytical solutions
+plot_ana = False
+
+n = 2 # wave number
+
+# -
+
+# ### Analytical Solution
+
+if plot_ana:
+    solution_above = assess.CylindricalStokesSolutionDeltaFreeSlip(n, +1, Rp=r_o, Rm=r_i, rp=r_int, nu=1.0, g=-1.0)
+    solution_below = assess.CylindricalStokesSolutionDeltaFreeSlip(n, -1, Rp=r_o, Rm=r_i, rp=r_int, nu=1.0, g=-1.0)
+
+if plot_ana:
+    mesh_ana = uw.meshing.AnnulusInternalBoundary(radiusOuter=r_o, 
+                                                  radiusInternal=r_int, 
+                                                  radiusInner=r_i, 
+                                                  cellSize_Inner=res,
+                                                  cellSize_Internal=res*res_int_fac,
+                                                  cellSize_Outer=res,)
+
+if plot_ana:
+    v_ana = uw.discretisation.MeshVariable(r"\mathbf{u_a}", mesh_ana, 2, degree=2)
+    p_ana = uw.discretisation.MeshVariable(r"p_a", mesh_ana, 1, degree=1)
+    rho_ana = uw.discretisation.MeshVariable(r"rho_a", mesh_ana, 1, degree=1)
+
+if uw.mpi.size == 1 and plot_ana:
+
+    pvmesh = vis.mesh_to_pv_mesh(mesh_ana)
+   
+    pl = pv.Plotter(window_size=(750, 750))
+
+    pl.add_mesh(pvmesh, edge_color="Grey", show_edges=True, use_transparency=False, opacity=1.0, )
+
+    pl.show(cpos="xy")
+
+if plot_ana:
+    r_ana, th_ana = mesh_ana.CoordinateSystem.xR
+
+if plot_ana:
+    with mesh_ana.access(v_ana, p_ana, rho_ana):
+        # velocities
+        r = uw.function.evalf(r_ana, v_ana.coords)
+        for i, coord in enumerate(v_ana.coords):
+            if r[i]>r_int:
+                v_ana.data[i] = solution_above.velocity_cartesian(coord)
+            else:
+                v_ana.data[i] = solution_below.velocity_cartesian(coord)
+        
+        
+        # pressure 
+        r = uw.function.evalf(r_ana, p_ana.coords)
+        for i, coord in enumerate(p_ana.coords):
+            if r[i]>r_int:
+                p_ana.data[i] = solution_above.pressure_cartesian(coord)
+            else:
+                p_ana.data[i] = solution_below.pressure_cartesian(coord)
+    
+        # density
+        r = uw.function.evalf(r_ana, rho_ana.coords)
+        for i, coord in enumerate(rho_ana.coords):
+            if r[i]>r_int:
+                rho_ana.data[i] = solution_above.radial_stress_cartesian(coord)
+            else:
+                rho_ana.data[i] = solution_below.radial_stress_cartesian(coord)
+
+if uw.mpi.size == 1 and plot_ana:
+    pvmesh_ana = vis.mesh_to_pv_mesh(mesh_ana)
+    pvmesh_ana.point_data["V"] = vis.vector_fn_to_pv_points(pvmesh_ana, v_ana.sym)
+    pvmesh_ana.point_data["Vmag"] = vis.scalar_fn_to_pv_points(pvmesh_ana, 
+                                                               sympy.sqrt(v_ana.sym.dot(v_ana.sym)))
+    
+    print(pvmesh_ana.point_data["Vmag"].min(), pvmesh_ana.point_data["Vmag"].max())
+    
+    velocity_points_ana = vis.meshVariable_to_pv_cloud(v_ana)
+    velocity_points_ana.point_data["V"] = vis.vector_fn_to_pv_points(velocity_points_ana, v_ana.sym)
+    
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh_ana, cmap=cmc.lapaz.resampled(11), edge_color="Grey",
+                scalars="Vmag", show_edges=False, use_transparency=False,
+                opacity=0.7, clim=[0., 0.05] )
+    pl.add_arrows(velocity_points_ana.points[::5], velocity_points_ana.point_data["V"][::5], 
+                  mag=5e0, color='k')
+
+    pl.show(cpos="xy")
+
+if uw.mpi.size == 1 and plot_ana:
+    pvmesh_ana = vis.mesh_to_pv_mesh(mesh_ana)
+    pvmesh_ana.point_data["P"] = vis.scalar_fn_to_pv_points(pvmesh_ana, p_ana.sym)
+
+    print(pvmesh_ana.point_data["P"].min(), pvmesh_ana.point_data["P"].max())
+   
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh_ana, cmap=cmc.vik.resampled(41), edge_color="Grey",
+                scalars="P", show_edges=False, use_transparency=False,
+                opacity=1.0, clim=[-0.65, 0.65] )
+
+    pl.show(cpos="xy")
+
+# +
+# This one is actually tau_rr
+
+if uw.mpi.size == 1 and plot_ana:
+    pvmesh_ana = vis.mesh_to_pv_mesh(mesh_ana)
+    pvmesh_ana.point_data["rho"] = vis.scalar_fn_to_pv_points(pvmesh_ana, rho_ana.sym)
+
+    print(pvmesh_ana.point_data["rho"].min(), pvmesh_ana.point_data["rho"].max())
+    
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh_ana, cmap=cmc.roma.resampled(41), edge_color="Grey",
+                scalars="rho", show_edges=False, use_transparency=False,
+                opacity=1.0) # , clim=[-0.8, 0.8] )
+
+    pl.show(cpos="xy")
+# -
+
+# ### Create Mesh for Numerical Solution
+
+# mesh
+mesh_uw = uw.meshing.AnnulusInternalBoundary(radiusOuter=r_o, 
+                                             radiusInternal=r_int, 
+                                             radiusInner=r_i, 
+                                             cellSize_Inner=res,
+                                             cellSize_Internal=res*res_int_fac,
+                                             cellSize_Outer=res,)
+
+# mesh variables
+v_uw = uw.discretisation.MeshVariable(r"\mathbf{u}", mesh_uw, 2, degree=2)
+p_uw = uw.discretisation.MeshVariable(r"p", mesh_uw, 1, degree=1, continuous=True)
+v_err = uw.discretisation.MeshVariable(r"\mathbf{u_e}", mesh_uw, 2, degree=2)
+p_err = uw.discretisation.MeshVariable(r"p_e", mesh_uw, 1, degree=1, continuous=True)
+
+# Some useful coordinate stuff
+unit_rvec = mesh_uw.CoordinateSystem.unit_e_0
+r_uw, th_uw = mesh_uw.CoordinateSystem.xR
+
+# +
+# Create Stokes object
+
+stokes = Stokes(mesh_uw, velocityField=v_uw, pressureField=p_uw, solver_name="stokes")
+
+stokes.constitutive_model = uw.constitutive_models.ViscousFlowModel
+stokes.constitutive_model.Parameters.viscosity = 1.0
+stokes.saddle_preconditioner = 1.0
+
+rho = sympy.cos(n*th_uw)  
+
+Gamma = unit_rvec 
+Gamma = mesh_uw.Gamma 
+penalty = 1e6
+
+stokes.add_natural_bc(penalty * Gamma.dot(v_uw.sym) *  Gamma, "Upper")
+stokes.add_natural_bc(penalty * Gamma.dot(v_uw.sym) *  Gamma, "Lower")
+stokes.add_natural_bc(-rho * unit_rvec, "Internal")
+
+stokes.bodyforce = sympy.Matrix([0,0])
+# -
+
+mesh_uw.dm.view()
+
+if uw.mpi.size == 1:
+    pvmesh = vis.mesh_to_pv_mesh(mesh_uw)
+    pvmesh.point_data["rho"] = vis.scalar_fn_to_pv_points(pvmesh, rho * sympy.exp(-1e5 * ((r_uw - r_int) ** 2)))
+
+    print(pvmesh.point_data["rho"].min(), pvmesh.point_data["rho"].max())
+    
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh, cmap=cmc.roma.resampled(31), edge_color="Grey",
+                scalars="rho", show_edges=False, use_transparency=False,
+                opacity=1.0, ) # clim=[-1, 1] )
+
+    pl.show(cpos="xy")
+
+# +
+# Stokes settings
+
+stokes.tolerance = 1.0e-5
+stokes.petsc_options["ksp_monitor"] = None
+
+stokes.petsc_options["snes_type"] = "newtonls"
+stokes.petsc_options["ksp_type"] = "fgmres"
+
+# stokes.petsc_options.setValue("fieldsplit_velocity_pc_type", "mg")
+# stokes.petsc_options.setValue("fieldsplit_velocity_pc_mg_type", "kaskade")
+# stokes.petsc_options.setValue("fieldsplit_velocity_pc_mg_cycle_type", "w")
+
+stokes.petsc_options["fieldsplit_velocity_mg_coarse_pc_type"] = "svd"
+
+# stokes.petsc_options[f"fieldsplit_velocity_ksp_type"] = "fcg"
+# stokes.petsc_options[f"fieldsplit_velocity_mg_levels_ksp_type"] = "chebyshev"
+# stokes.petsc_options[f"fieldsplit_velocity_mg_levels_ksp_max_it"] = 5
+# stokes.petsc_options[f"fieldsplit_velocity_mg_levels_ksp_converged_maxits"] = None
+
+# gasm is super-fast ... but mg seems to be bulletproof
+# gamg is toughest wrt viscosity
+
+# stokes.petsc_options.setValue("fieldsplit_pressure_pc_type", "gamg")
+# stokes.petsc_options.setValue("fieldsplit_pressure_pc_mg_type", "additive")
+# stokes.petsc_options.setValue("fieldsplit_pressure_pc_mg_cycle_type", "v")
+
+# # # mg, multiplicative - very robust ... similar to gamg, additive
+
+# stokes.petsc_options.setValue("fieldsplit_pressure_pc_type", "mg")
+# stokes.petsc_options.setValue("fieldsplit_pressure_pc_mg_type", "multiplicative")
+# stokes.petsc_options.setValue("fieldsplit_pressure_pc_mg_cycle_type", "v")
+# -
+
+stokes._setup_pointwise_functions()
+stokes._setup_discretisation()
+stokes._setup_solver()
+
+stokes.solve(verbose=True)
+
+if uw.mpi.size == 1 and plot_ana:
+
+    with mesh_uw.access(v_uw, p_uw, v_err, p_err):
+            # velocities
+            r = uw.function.evalf(r_uw, v_err.coords)
+            for i, coord in enumerate(v_err.coords):
+                if r[i]>r_int:
+                    v_err.data[i] = v_uw.data[i] - solution_above.velocity_cartesian(coord)
+                else:
+                    v_err.data[i] = v_uw.data[i] - solution_below.velocity_cartesian(coord)
+            
+            
+            # pressure 
+            r = uw.function.evalf(r_uw, p_err.coords)
+            for i, coord in enumerate(p_err.coords):
+                if r[i]>r_int:
+                    p_err.data[i] = p_uw.data[i] - solution_above.pressure_cartesian(coord)
+                else:
+                    p_err.data[i] = p_uw.data[i] - solution_below.pressure_cartesian(coord)
+
+# plotting velocities from uw
+if uw.mpi.size == 1:
+    pvmesh = vis.mesh_to_pv_mesh(mesh_uw)
+    pvmesh.point_data["V_uw"] = vis.vector_fn_to_pv_points(pvmesh, v_uw.sym)
+    pvmesh.point_data["Vmag_uw"] = vis.scalar_fn_to_pv_points(pvmesh, sympy.sqrt(v_uw.sym.dot(v_uw.sym)))
+
+    print(pvmesh.point_data["Vmag_uw"].min(), pvmesh.point_data["Vmag_uw"].max())
+    
+    velocity_points = vis.meshVariable_to_pv_cloud(v_uw)
+    velocity_points.point_data["V_uw"] = vis.vector_fn_to_pv_points(velocity_points, v_uw.sym)
+
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh, cmap=cmc.lapaz.resampled(11), edge_color="Grey",
+                scalars="Vmag_uw", show_edges=False, use_transparency=False,
+                opacity=0.7,)# clim=[0., 0.05] )
+    pl.add_arrows(velocity_points.points[::10], velocity_points.point_data["V_uw"][::10], mag=10, color='k')
+
+    pl.show(cpos="xy")
+
+# plotting error in velocities
+if uw.mpi.size == 1:
+    pvmesh = vis.mesh_to_pv_mesh(mesh_uw)
+    
+    pvmesh.point_data["V_err"] = vis.vector_fn_to_pv_points(pvmesh, v_err.sym)
+    pvmesh.point_data["Vmag_err"] = vis.scalar_fn_to_pv_points(pvmesh, sympy.sqrt(v_err.sym.dot(v_err.sym)))
+
+    print(pvmesh.point_data["Vmag_err"].min(), pvmesh.point_data["Vmag_err"].max())
+    
+    velocity_points = vis.meshVariable_to_pv_cloud(v_uw)
+    velocity_points.point_data["V_err"] = vis.vector_fn_to_pv_points(velocity_points, v_err.sym)
+
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh, cmap=cmc.lapaz.resampled(11), edge_color="Grey",
+                scalars="Vmag_err", show_edges=False, use_transparency=False,
+                opacity=0.7, clim=[0., 0.005] )
+    pl.add_arrows(velocity_points.points[::50], velocity_points.point_data["V_err"][::50], mag=100, color='k')
+
+    pl.show(cpos="xy")
+
+# plotting pressure from uw
+if uw.mpi.size == 1:
+    pvmesh = vis.mesh_to_pv_mesh(mesh_uw)
+    pvmesh.point_data["P_uw"] = vis.scalar_fn_to_pv_points(pvmesh, p_uw.sym)
+
+    print(pvmesh.point_data["P_uw"].min(), pvmesh.point_data["P_uw"].max())
+   
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh, cmap=cmc.vik.resampled(41), edge_color="Grey",
+                scalars="P_uw", show_edges=False, use_transparency=False,
+                opacity=1.0, clim=[-0.85, 0.85] )
+
+    pl.show(cpos="xy")
+
+# plotting error in uw
+if uw.mpi.size == 1:
+    pvmesh = vis.mesh_to_pv_mesh(mesh_uw)
+    pvmesh.point_data["P_err"] = vis.scalar_fn_to_pv_points(pvmesh, p_err.sym)
+
+    print(pvmesh.point_data["P_err"].min(), pvmesh.point_data["P_err"].max())
+   
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh, cmap=cmc.vik.resampled(41), edge_color="Grey",
+                scalars="P_err", show_edges=False, use_transparency=False,
+                opacity=1.0, clim=[-0.085, 0.085] )
+
+    pl.show(cpos="xy")
+
+# pressure error (L2 norm)
+p_err.stats()[5]/p_ana.stats()[5]
+
+mesh_uw.dm.view()
+
+

--- a/Jupyterbook/Notebooks/Examples-Utilities/Ex_Stokes_Annulus_Benchmark_Thieulot.py
+++ b/Jupyterbook/Notebooks/Examples-Utilities/Ex_Stokes_Annulus_Benchmark_Thieulot.py
@@ -1,0 +1,328 @@
+# ## Annulus Benchmark: Isoviscous Incompressible Stokes
+#
+# ### Case: Infinitely thin density anomaly at $r = r'$
+# #### [Benchmark paper](https://gmd.copernicus.org/articles/14/1899/2021/) 
+#
+# *Author: [Thyagarajulu Gollapalli](https://github.com/gthyagi)*
+
+# to fix trame issue
+import nest_asyncio
+nest_asyncio.apply()
+
+# +
+import underworld3 as uw
+from underworld3.systems import Stokes
+
+import numpy as np
+import sympy
+from sympy import lambdify
+import os
+import matplotlib.pyplot as plt
+import cmcrameri.cm as cmc
+import assess
+# -
+
+os.environ["SYMPY_USE_CACHE"] = "no"
+
+if uw.mpi.size == 1:
+    import pyvista as pv
+    import underworld3.visualisation as vis
+
+# mesh options
+res = 1/32
+res_int_fac = 1/2
+r_o = 2.0
+r_int = 1.8
+r_i = 1.0
+
+# visualize analytical solutions
+plot_ana = True
+
+# ### Analytical Solution
+
+if plot_ana:
+    n = 2 # wave number
+    solution_above = assess.CylindricalStokesSolutionDeltaFreeSlip(n, +1, Rp=r_o, Rm=r_i, rp=r_int, nu=1.0, g=-1.0)
+    solution_below = assess.CylindricalStokesSolutionDeltaFreeSlip(n, -1, Rp=r_o, Rm=r_i, rp=r_int, nu=1.0, g=-1.0)
+
+if plot_ana:
+    mesh_ana = uw.meshing.AnnulusInternalBoundary(radiusOuter=r_o, 
+                                                  radiusInternal=r_int, 
+                                                  radiusInner=r_i, 
+                                                  cellSize_Inner=res,
+                                                  cellSize_Internal=res*res_int_fac,
+                                                  cellSize_Outer=res,)
+
+if plot_ana:
+    v_ana = uw.discretisation.MeshVariable(r"\mathbf{u_a}", mesh_ana, 2, degree=2)
+    p_ana = uw.discretisation.MeshVariable(r"p_a", mesh_ana, 1, degree=1)
+    rho_ana = uw.discretisation.MeshVariable(r"rho_a", mesh_ana, 1, degree=1)
+
+if uw.mpi.size == 1 and plot_ana:
+
+    pvmesh = vis.mesh_to_pv_mesh(mesh_ana)
+   
+    pl = pv.Plotter(window_size=(750, 750))
+
+    pl.add_mesh(pvmesh, edge_color="Grey", show_edges=True, use_transparency=False, opacity=1.0, )
+
+    pl.show(cpos="xy")
+
+if plot_ana:
+    r_ana, th_ana = mesh_ana.CoordinateSystem.xR
+
+if plot_ana:
+    with mesh_ana.access(v_ana, p_ana, rho_ana):
+        # velocities
+        r = uw.function.evalf(r_ana, v_ana.coords)
+        for i, coord in enumerate(v_ana.coords):
+            if r[i]>r_int:
+                v_ana.data[i] = solution_above.velocity_cartesian(coord)
+            else:
+                v_ana.data[i] = solution_below.velocity_cartesian(coord)
+        
+        
+        # pressure 
+        r = uw.function.evalf(r_ana, p_ana.coords)
+        for i, coord in enumerate(p_ana.coords):
+            if r[i]>r_int:
+                p_ana.data[i] = solution_above.pressure_cartesian(coord)
+            else:
+                p_ana.data[i] = solution_below.pressure_cartesian(coord)
+    
+        # density
+        r = uw.function.evalf(r_ana, rho_ana.coords)
+        for i, coord in enumerate(rho_ana.coords):
+            if r[i]>r_int:
+                rho_ana.data[i] = solution_above.radial_stress_cartesian(coord)
+            else:
+                rho_ana.data[i] = solution_below.radial_stress_cartesian(coord)
+
+if uw.mpi.size == 1 and plot_ana:
+    pvmesh_ana = vis.mesh_to_pv_mesh(mesh_ana)
+    pvmesh_ana.point_data["V"] = vis.vector_fn_to_pv_points(pvmesh_ana, v_ana.sym)
+    pvmesh_ana.point_data["Vmag"] = vis.scalar_fn_to_pv_points(pvmesh_ana, 
+                                                               sympy.sqrt(v_ana.sym.dot(v_ana.sym)))
+    
+    print(pvmesh_ana.point_data["Vmag"].min(), pvmesh_ana.point_data["Vmag"].max())
+    
+    velocity_points_ana = vis.meshVariable_to_pv_cloud(v_ana)
+    velocity_points_ana.point_data["V"] = vis.vector_fn_to_pv_points(velocity_points_ana, v_ana.sym)
+    
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh_ana, cmap=cmc.lapaz.resampled(11), edge_color="Grey",
+                scalars="Vmag", show_edges=False, use_transparency=False,
+                opacity=0.7, clim=[0., 0.05] )
+    pl.add_arrows(velocity_points_ana.points[::10], velocity_points_ana.point_data["V"][::10], 
+                  mag=5, color='k')
+
+    pl.show(cpos="xy")
+
+if uw.mpi.size == 1 and plot_ana:
+    pvmesh_ana = vis.mesh_to_pv_mesh(mesh_ana)
+    pvmesh_ana.point_data["P"] = vis.scalar_fn_to_pv_points(pvmesh_ana, p_ana.sym)
+
+    print(pvmesh_ana.point_data["P"].min(), pvmesh_ana.point_data["P"].max())
+   
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh_ana, cmap=cmc.vik.resampled(41), edge_color="Grey",
+                scalars="P", show_edges=False, use_transparency=False,
+                opacity=1.0, clim=[-0.65, 0.65] )
+
+    pl.show(cpos="xy")
+
+if uw.mpi.size == 1 and plot_ana:
+    pvmesh_ana = vis.mesh_to_pv_mesh(mesh_ana)
+    pvmesh_ana.point_data["rho"] = vis.scalar_fn_to_pv_points(pvmesh_ana, rho_ana.sym)
+
+    print(pvmesh_ana.point_data["rho"].min(), pvmesh_ana.point_data["rho"].max())
+    
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh_ana, cmap=cmc.roma.resampled(41), edge_color="Grey",
+                scalars="rho", show_edges=False, use_transparency=False,
+                opacity=1.0, clim=[-0.8, 0.8] )
+
+    pl.show(cpos="xy")
+
+# ### Create Mesh for Numerical Solution
+
+# mesh
+mesh_uw = uw.meshing.AnnulusInternalBoundary(radiusOuter=r_o, 
+                                             radiusInternal=r_int, 
+                                             radiusInner=r_i, 
+                                             cellSize_Inner=res,
+                                             cellSize_Internal=res*res_int_fac,
+                                             cellSize_Outer=res,)
+
+# mesh variables
+v_uw = uw.discretisation.MeshVariable(r"\mathbf{u}", mesh_uw, 2, degree=2)
+p_uw = uw.discretisation.MeshVariable(r"p", mesh_uw, 1, degree=1)
+v_err = uw.discretisation.MeshVariable(r"\mathbf{u_e}", mesh_uw, 2, degree=2)
+p_err = uw.discretisation.MeshVariable(r"p_e", mesh_uw, 1, degree=1)
+
+# Some useful coordinate stuff
+unit_rvec = mesh_uw.CoordinateSystem.unit_e_0
+r_uw, th_uw = mesh_uw.CoordinateSystem.xR
+
+# +
+# Create Stokes object
+
+stokes = Stokes(mesh_uw, velocityField=v_uw, pressureField=p_uw, solver_name="stokes")
+
+stokes.constitutive_model = uw.constitutive_models.ViscousFlowModel
+stokes.constitutive_model.Parameters.viscosity = 1.0
+stokes.saddle_preconditioner = 1.0
+
+rho = sympy.cos(n*th_uw) * sympy.exp(-1e5 * ((r_uw - r_int) ** 2)) 
+
+penalty = 1e7
+Gamma = mesh_uw.Gamma
+stokes.add_natural_bc(penalty * Gamma.dot(v_uw.sym) *  Gamma, "Upper")
+stokes.add_natural_bc(penalty * Gamma.dot(v_uw.sym) *  Gamma, "Lower")
+stokes.add_natural_bc(-rho * unit_rvec, "Internal")
+
+stokes.bodyforce = sympy.Matrix([0,0])
+# -
+
+if uw.mpi.size == 1:
+    pvmesh = vis.mesh_to_pv_mesh(mesh_uw)
+    pvmesh.point_data["rho"] = vis.scalar_fn_to_pv_points(pvmesh, rho)
+
+    print(pvmesh.point_data["rho"].min(), pvmesh.point_data["rho"].max())
+    
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh, cmap=cmc.roma.resampled(31), edge_color="Grey",
+                scalars="rho", show_edges=False, use_transparency=False,
+                opacity=1.0, clim=[-1, 1] )
+
+    pl.show(cpos="xy")
+
+# +
+# Stokes settings
+
+stokes.tolerance = 1.0e-6
+stokes.petsc_options["ksp_monitor"] = None
+
+stokes.petsc_options["snes_type"] = "newtonls"
+stokes.petsc_options["ksp_type"] = "fgmres"
+
+# stokes.petsc_options.setValue("fieldsplit_velocity_pc_type", "mg")
+stokes.petsc_options.setValue("fieldsplit_velocity_pc_mg_type", "kaskade")
+stokes.petsc_options.setValue("fieldsplit_velocity_pc_mg_cycle_type", "w")
+
+stokes.petsc_options["fieldsplit_velocity_mg_coarse_pc_type"] = "svd"
+
+stokes.petsc_options[f"fieldsplit_velocity_ksp_type"] = "fcg"
+stokes.petsc_options[f"fieldsplit_velocity_mg_levels_ksp_type"] = "chebyshev"
+stokes.petsc_options[f"fieldsplit_velocity_mg_levels_ksp_max_it"] = 5
+stokes.petsc_options[f"fieldsplit_velocity_mg_levels_ksp_converged_maxits"] = None
+
+# gasm is super-fast ... but mg seems to be bulletproof
+# gamg is toughest wrt viscosity
+
+stokes.petsc_options.setValue("fieldsplit_pressure_pc_type", "gamg")
+stokes.petsc_options.setValue("fieldsplit_pressure_pc_mg_type", "additive")
+stokes.petsc_options.setValue("fieldsplit_pressure_pc_mg_cycle_type", "v")
+
+# # # mg, multiplicative - very robust ... similar to gamg, additive
+
+# stokes.petsc_options.setValue("fieldsplit_pressure_pc_type", "mg")
+# stokes.petsc_options.setValue("fieldsplit_pressure_pc_mg_type", "multiplicative")
+# stokes.petsc_options.setValue("fieldsplit_pressure_pc_mg_cycle_type", "v")
+# -
+
+stokes.solve()
+
+with mesh_uw.access(v_uw, p_uw, v_err, p_err):
+        # velocities
+        r = uw.function.evalf(r_uw, v_err.coords)
+        for i, coord in enumerate(v_err.coords):
+            if r[i]>r_int:
+                v_err.data[i] = v_uw.data[i] - solution_above.velocity_cartesian(coord)
+            else:
+                v_err.data[i] = v_uw.data[i] - solution_below.velocity_cartesian(coord)
+        
+        
+        # pressure 
+        r = uw.function.evalf(r_uw, p_err.coords)
+        for i, coord in enumerate(p_err.coords):
+            if r[i]>r_int:
+                p_err.data[i] = p_uw.data[i] - solution_above.pressure_cartesian(coord)
+            else:
+                p_err.data[i] = p_uw.data[i] - solution_below.pressure_cartesian(coord)
+
+# plotting velocities from uw
+if uw.mpi.size == 1:
+    pvmesh = vis.mesh_to_pv_mesh(mesh_uw)
+    pvmesh.point_data["V_uw"] = vis.vector_fn_to_pv_points(pvmesh, v_uw.sym)
+    pvmesh.point_data["Vmag_uw"] = vis.scalar_fn_to_pv_points(pvmesh, sympy.sqrt(v_uw.sym.dot(v_uw.sym)))
+
+    print(pvmesh.point_data["Vmag_uw"].min(), pvmesh.point_data["Vmag_uw"].max())
+    
+    velocity_points = vis.meshVariable_to_pv_cloud(v_uw)
+    velocity_points.point_data["V_uw"] = vis.vector_fn_to_pv_points(velocity_points, v_uw.sym)
+
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh, cmap=cmc.lapaz.resampled(11), edge_color="Grey",
+                scalars="Vmag_uw", show_edges=False, use_transparency=False,
+                opacity=0.1, clim=[0., 0.05] )
+    pl.add_arrows(velocity_points.points[::10], velocity_points.point_data["V_uw"][::10], mag=1e1, color='k')
+
+    pl.show(cpos="xy")
+
+# plotting errror in velocities
+if uw.mpi.size == 1:
+    pvmesh = vis.mesh_to_pv_mesh(mesh_uw)
+    
+    pvmesh.point_data["V_err"] = vis.vector_fn_to_pv_points(pvmesh, v_err.sym)
+    pvmesh.point_data["Vmag_err"] = vis.scalar_fn_to_pv_points(pvmesh, sympy.sqrt(v_err.sym.dot(v_err.sym)))
+
+    print(pvmesh.point_data["Vmag_err"].min(), pvmesh.point_data["Vmag_err"].max())
+    
+    velocity_points = vis.meshVariable_to_pv_cloud(v_uw)
+    velocity_points.point_data["V_err"] = vis.vector_fn_to_pv_points(velocity_points, v_err.sym)
+
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh, cmap=cmc.lapaz.resampled(11), edge_color="Grey",
+                scalars="Vmag_err", show_edges=False, use_transparency=False,
+                opacity=0.7, clim=[0., 0.005] )
+    pl.add_arrows(velocity_points.points[::50], velocity_points.point_data["V_err"][::50], mag=1e-1, color='k')
+
+    pl.show(cpos="xy")
+
+# plotting pressure from uw
+if uw.mpi.size == 1:
+    pvmesh = vis.mesh_to_pv_mesh(mesh_uw)
+    pvmesh.point_data["P_uw"] = vis.scalar_fn_to_pv_points(pvmesh, p_uw.sym)
+
+    print(pvmesh.point_data["P_uw"].min(), pvmesh.point_data["P_uw"].max())
+   
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh, cmap=cmc.vik.resampled(41), edge_color="Grey",
+                scalars="P_uw", show_edges=False, use_transparency=False,
+                opacity=1.0, clim=[-0.85, 0.85] )
+
+    pl.show(cpos="xy")
+
+# plotting error in uw
+if uw.mpi.size == 1:
+    pvmesh = vis.mesh_to_pv_mesh(mesh_uw)
+    pvmesh.point_data["P_err"] = vis.scalar_fn_to_pv_points(pvmesh, p_err.sym)
+
+    print(pvmesh.point_data["P_err"].min(), pvmesh.point_data["P_err"].max())
+   
+    pl = pv.Plotter(window_size=(750, 750))
+    pl.add_mesh(pvmesh, cmap=cmc.vik.resampled(41), edge_color="Grey",
+                scalars="P_err", show_edges=False, use_transparency=False,
+                opacity=1.0, clim=[-0.085, 0.085] )
+
+    pl.show(cpos="xy")
+
+# pressure error (L2 norm)
+p_err.stats()[5]/p_ana.stats()[5]
+
+mesh_uw.dm.view()
+
+
+
+

--- a/Jupyterbook/Notebooks/Examples-Utilities/Ex_SurfaceIntegrals_BCs.py
+++ b/Jupyterbook/Notebooks/Examples-Utilities/Ex_SurfaceIntegrals_BCs.py
@@ -32,6 +32,7 @@ meshQuad = uw.meshing.StructuredQuadBox(
         maxCoords=(maxX, maxY), qdegree=3)
 
 meshTri = uw.meshing.UnstructuredSimplexBox(
+        regular=True,
         cellSize=1/2, 
         minCoords=(minX, minY), 
         maxCoords=(maxX, maxY), qdegree=3)
@@ -197,7 +198,10 @@ p3 = stokes3.Unknowns.p
 stokes3.add_essential_bc( [0.,0.], "Bottom")         # no slip on the base
 stokes3.add_essential_bc( [0.,sympy.oo], "Left")     # free slip Left/Right
 stokes3.add_essential_bc( [0.,sympy.oo], "Right")    # free slip Left/Right
-stokes3.add_natural_bc(   [0.,1000000*v3.sym[1]], "Top")              # Top "free slip / penalty"
+# stokes3.add_natural_bc(   [0.,1000000*v3.sym[1]], "Top")              # Top "free slip / penalty"
+
+Gamma = mesh.Gamma # sympy.Piecewise((mesh.Gamma, x < 0.5), mesh.CoordinateSystem.unit_j
+stokes3.add_natural_bc( 1.0e6 *  Gamma.dot(v3.sym) * Gamma, "Top")              # Top "free slip / penalty"
 
 stokes3.bodyforce = sympy.Matrix([0, sympy.sin(x*sympy.pi)])
 
@@ -208,12 +212,7 @@ stokes3.solve(verbose=False, debug=False, zero_init_guess=True, picard=2)
 
 
 JacViewer(stokes3)
-JacDiffViewer(stokes3, stokes0)
-
-
-stokes3.solve(verbose=True, debug=True, zero_init_guess=True, picard=2)
-JacViewer(stokes3)
-JacDiffViewer(stokes3, stokes0)
+# JacDiffViewer(stokes3, stokes0)
 
 
 # +

--- a/Jupyterbook/Notebooks/WIP/SurfaceNormals.py
+++ b/Jupyterbook/Notebooks/WIP/SurfaceNormals.py
@@ -1,0 +1,125 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.0
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %%
+
+# to fix trame issue
+import nest_asyncio
+nest_asyncio.apply()
+
+import petsc4py
+from petsc4py import PETSc
+
+import underworld3 as uw
+from underworld3.systems import Stokes
+from underworld3 import function
+
+import numpy as np
+import sympy
+
+res = 0.2
+r_o = 2
+r_int = 1.8
+r_i = 1
+
+free_slip_upper = True
+
+options = PETSc.Options()
+# options["help"] = None
+# options["pc_type"]  = "svd"
+# options["dm_plex_check_all"] = None
+
+import os
+
+os.environ["SYMPY_USE_CACHE"] = "no"
+
+
+# %%
+meshball = uw.meshing.AnnulusInternalBoundary(radiusOuter=r_o, 
+                                              radiusInternal=r_int, 
+                                              radiusInner=r_i, 
+                                              cellSize_Inner=res,
+                                              cellSize_Internal=res*0.5,
+                                              cellSize_Outer=res,
+                                              qdegree = 3,
+                                              degree=1,
+                                              filename="tmp_fixedstarsMesh.msh")
+meshball.dm.view()
+
+# %%
+normal_vector = uw.discretisation.MeshVariable(r"\mathbf{n}", meshball, 2, degree=2)
+
+# %%
+projection = uw.systems.Vector_Projection(meshball, normal_vector)
+projection.uw_function = sympy.Matrix([[0,0]])
+projection.smoothing = 1.0e-3
+
+GammaNorm = meshball.Gamma.dot(meshball.CoordinateSystem.unit_e_0) / sympy.sqrt(meshball.Gamma.dot(meshball.Gamma))
+
+projection.add_natural_bc(meshball.Gamma * GammaNorm, "Upper")
+projection.add_natural_bc(meshball.Gamma * GammaNorm, "Lower")
+projection.add_natural_bc(meshball.Gamma * GammaNorm, "Internal")
+
+projection.solve(verbose=True, debug=True)
+
+with meshball.access(normal_vector):
+    normal_vector.data[:,:] /= np.sqrt(normal_vector.data[:,0]**2 + normal_vector.data[:,1]**2).reshape(-1,1)
+
+# %%
+# check the mesh if in a notebook / serial
+
+if uw.mpi.size == 1:
+    import pyvista as pv
+    import underworld3.visualisation as vis
+
+    pvmesh = vis.mesh_to_pv_mesh(meshball)
+    pvmesh.point_data["N"] = vis.vector_fn_to_pv_points(pvmesh, normal_vector.sym)
+    pvmesh.point_data["R"] = vis.vector_fn_to_pv_points(pvmesh, meshball.CoordinateSystem.unit_e_0)
+
+    evaluation_points = vis.meshVariable_to_pv_cloud(normal_vector)
+    evaluation_points.point_data["N"] = vis.vector_fn_to_pv_points(evaluation_points, normal_vector.sym)
+    evaluation_points.point_data["R"] = vis.vector_fn_to_pv_points(evaluation_points, -meshball.CoordinateSystem.unit_e_0)
+    evaluation_points.point_data["dR"] = evaluation_points.point_data["N"] - evaluation_points.point_data["R"]
+
+    # pvmesh.point_data["P"] = vis.scalar_fn_to_pv_points(pvmesh, p_cont.sym)
+    # pvmesh.point_data["T"] = vis.scalar_fn_to_pv_points(pvmesh, t_init)
+    # pvmesh.point_data["V"] = vis.vector_fn_to_pv_points(pvmesh, v_soln.sym)
+
+    pl = pv.Plotter(window_size=(750, 750))
+
+    pl.add_mesh(
+        pvmesh,
+        cmap="coolwarm",
+        edge_color="Grey",
+        show_edges=True,
+        use_transparency=False,
+        opacity=1.0,
+        show_scalar_bar=False
+    )
+
+    # pl.add_arrows(evaluation_points.points, evaluation_points.point_data["N"], mag=0.1)
+    # pl.add_arrows(evaluation_points.points, evaluation_points.point_data["R"], mag=0.1)
+    pl.add_arrows(evaluation_points.points, evaluation_points.point_data["dR"], mag=10)
+    # pl.add_mesh(pvstream, opacity=0.3, show_scalar_bar=False)
+
+
+    pl.show(cpos="xy")
+
+# %%
+# ls -trl
+
+# %%
+
+# %%

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -x
+
+# Run simple tests
+pytest tests/test_00*py
+
+# Spatial / calculation tests
+pytest tests/test_01*py tests/test_05*py tests/test_06*py
+
+# Solver / system tests (basic solver problems)
+pytest tests/test_1000*py tests/test_1001*py 
+
+# Solver / system tests (advanced solver problems)
+pytest tests/test_1002*py 
+
+# Darcy is a mixed solver with projection and poisson
+pytest tests/test_1004*py 
+
+# Swarm / Advection tests
+pytest tests/test_1003*py tests/test_1010*py

--- a/tests/test_1004_DarcyCartesian.py
+++ b/tests/test_1004_DarcyCartesian.py
@@ -48,7 +48,7 @@ meshSimplex_box_regular = uw.meshing.UnstructuredSimplexBox(
         meshSimplex_box_regular,
     ],
 )
-def test_Darcy_boxmesh_noG(mesh):
+def test_Darcy_boxmesh_G_and_noG(mesh):
     # Reset the mesh if it still has things lying around from earlier tests
     mesh.dm.clearDS()
     mesh.dm.clearFields()
@@ -98,8 +98,8 @@ def test_Darcy_boxmesh_noG(mesh):
 
     darcy._v_projector.petsc_options["snes_rtol"] = 1.0e-6
     darcy._v_projector.smoothing = 1.0e-6
-    darcy._v_projector.add_dirichlet_bc(0.0, "Left", [0])
-    darcy._v_projector.add_dirichlet_bc(0.0, "Right", [0])
+    # darcy._v_projector.add_dirichlet_bc(0.0, "Left", [0])
+    # darcy._v_projector.add_dirichlet_bc(0.0, "Right", [0])
 
     # Solve darcy
     darcy.solve(verbose=True)
@@ -131,115 +131,9 @@ def test_Darcy_boxmesh_noG(mesh):
     # print(pressure_interp)
 
     # ### Compare analytical and numerical solution
-    assert np.allclose(pressure_analytic_noG, pressure_interp, atol=1e-2)
+    assert np.allclose(pressure_analytic_noG, pressure_interp, atol=3e-2)
 
-
-# +
-## Clean up / redefine the meshes so we have no interaction between tests
-
-# +
-### Quads
-
-meshStructuredQuadBox = uw.meshing.StructuredQuadBox(
-    elementRes=(int(res), int(res)),
-    minCoords=(minX, minY),
-    maxCoords=(maxX, maxY),
-    qdegree=2,
-)
-
-### Tris
-meshSimplex_box_irregular = uw.meshing.UnstructuredSimplexBox(
-    minCoords=(minX, minY),
-    maxCoords=(maxX, maxY),
-    cellSize=1 / res,
-    qdegree=2,
-    regular=True,
-)
-
-meshSimplex_box_regular = uw.meshing.UnstructuredSimplexBox(
-    minCoords=(minX, minY),
-    maxCoords=(maxX, maxY),
-    cellSize=1 / res,
-    qdegree=2,
-    regular=False,
-)
-
-
-# +
-@pytest.mark.parametrize(
-    "mesh",
-    [
-        meshStructuredQuadBox,
-        meshSimplex_box_irregular,
-        meshSimplex_box_regular,
-    ],
-)
-def test_Darcy_boxmesh_G(mesh):
-    # Reset the mesh if it still has things lying around from earlier tests
-    mesh.dm.clearDS()
-    mesh.dm.clearFields()
-    mesh.nuke_coords_and_rebuild()
-    mesh.dm.createDS()
-
-    p_soln = uw.discretisation.MeshVariable("P", mesh, 1, degree=2)
-    v_soln = uw.discretisation.MeshVariable("U", mesh, mesh.dim, degree=1)
-
-    # x and y coordinates
-    x = mesh.N.x
-    y = mesh.N.y
-
-    # #### Set up the Darcy solver
-    darcy = uw.systems.SteadyStateDarcy(mesh, p_soln, v_soln)
-    darcy.petsc_options.delValue("ksp_monitor")
-    darcy.petsc_options[
-        "snes_rtol"
-    ] = 1.0e-6  # Needs to be smaller than the contrast in properties
-    darcy.constitutive_model = uw.constitutive_models.DarcyFlowModel
-    darcy.petsc_options["snes_rtol"] = 1.0e-6
-    darcy.petsc_options["snes_monitor"] = None
-
-    # #### Set up the hydraulic conductivity layout
-    ### Groundwater pressure boundary condition on the bottom wall
-
-    max_pressure = 0.5
-
-    # +
-    # set up two materials
-
-    interfaceY = -0.26
-
-    k1 = 1.0
-    k2 = 1.0e-4
-
-    #### The piecewise version
-    kFunc = Piecewise((k1, y >= interfaceY), (k2, y < interfaceY), (1.0, True))
-
-    darcy.constitutive_model.Parameters.permeability = kFunc
-    darcy.constitutive_model.Parameters.s = sympy.Matrix([0, -1]).T
-    darcy.f = 0.0
-
-    # set up boundary conditions
-    darcy.add_dirichlet_bc([0.0], "Top")
-    darcy.add_dirichlet_bc([-1.0 * minY * max_pressure], "Bottom")
-
-    darcy._v_projector.petsc_options["snes_rtol"] = 1.0e-6
-
-    # -
-
-    # Solve darcy
-    darcy.solve(verbose=True)
-
-    # set up interpolation coordinates
-    ycoords = np.linspace(minY + 0.01 * (maxY - minY), maxY - 0.01 * (maxY - minY), 100)
-    xcoords = np.full_like(ycoords, -0.5)
-    xy_coords = np.column_stack([xcoords, ycoords])
-
-    pressure_interp = uw.function.evalf(p_soln.sym[0], xy_coords)
-
-    # #### Get analytical solution
-    La = -1.0 * interfaceY
-    Lb = 1.0 + interfaceY
-    dP = max_pressure
+    ## Suggest we re-solve right here for version with G to avoid all the re-definitions
 
     S = 1
     Pa = (dP / Lb - S + k1 / k2 * S) / (1.0 / Lb + k1 / k2 / La)
@@ -252,10 +146,13 @@ def test_Darcy_boxmesh_G(mesh):
         ],
     )
 
+    darcy.constitutive_model.Parameters.s = sympy.Matrix([0, -1]).T
+    darcy.solve()
+
+    pressure_interp = uw.function.evalf(p_soln.sym[0], xy_coords)
+
     # ### Compare analytical and numerical solution
-    assert np.allclose(pressure_analytic, pressure_interp, atol=1e-1)
+    assert np.allclose(pressure_analytic, pressure_interp, atol=3e-2)
 
 
-# -
-
-test_Darcy_boxmesh_G(meshSimplex_box_irregular)
+#

--- a/tests/test_1004_DarcyCartesian.py
+++ b/tests/test_1004_DarcyCartesian.py
@@ -49,6 +49,12 @@ meshSimplex_box_regular = uw.meshing.UnstructuredSimplexBox(
     ],
 )
 def test_Darcy_boxmesh_noG(mesh):
+    # Reset the mesh if it still has things lying around from earlier tests
+    mesh.dm.clearDS()
+    mesh.dm.clearFields()
+    mesh.nuke_coords_and_rebuild()
+    mesh.dm.createDS()
+
     p_soln = uw.discretisation.MeshVariable("P", mesh, 1, degree=2)
     v_soln = uw.discretisation.MeshVariable("U", mesh, mesh.dim, degree=1)
 
@@ -123,13 +129,9 @@ def test_Darcy_boxmesh_noG(mesh):
 
     # print(pressure_analytic_noG)
     # print(pressure_interp)
-    
 
     # ### Compare analytical and numerical solution
     assert np.allclose(pressure_analytic_noG, pressure_interp, atol=1e-2)
-
-
-    
 
 
 # +
@@ -173,6 +175,12 @@ meshSimplex_box_regular = uw.meshing.UnstructuredSimplexBox(
     ],
 )
 def test_Darcy_boxmesh_G(mesh):
+    # Reset the mesh if it still has things lying around from earlier tests
+    mesh.dm.clearDS()
+    mesh.dm.clearFields()
+    mesh.nuke_coords_and_rebuild()
+    mesh.dm.createDS()
+
     p_soln = uw.discretisation.MeshVariable("P", mesh, 1, degree=2)
     v_soln = uw.discretisation.MeshVariable("U", mesh, mesh.dim, degree=1)
 
@@ -189,7 +197,6 @@ def test_Darcy_boxmesh_G(mesh):
     darcy.constitutive_model = uw.constitutive_models.DarcyFlowModel
     darcy.petsc_options["snes_rtol"] = 1.0e-6
     darcy.petsc_options["snes_monitor"] = None
-    darcy.constitutive_model = uw.constitutive_models.DarcyFlowModel
 
     # #### Set up the hydraulic conductivity layout
     ### Groundwater pressure boundary condition on the bottom wall
@@ -245,7 +252,6 @@ def test_Darcy_boxmesh_G(mesh):
         ],
     )
 
-    
     # ### Compare analytical and numerical solution
     assert np.allclose(pressure_analytic, pressure_interp, atol=1e-1)
 
@@ -253,7 +259,3 @@ def test_Darcy_boxmesh_G(mesh):
 # -
 
 test_Darcy_boxmesh_G(meshSimplex_box_irregular)
-
-
-
-

--- a/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -367,8 +367,8 @@ class SNES_Scalar(Solver):
         ## Todo: some validity checking on the size / type of u_Field supplied
         if u_Field is None:
             self.Unknowns.u = uw.discretisation.MeshVariable( mesh=mesh, num_components=mesh.dim, 
-                                                      varname="Us{}".format(self.instance_number),
-                                                    vtype=uw.VarType.SCALAR, degree=degree, )
+                                                      varname="Us{}".format(SNES_Scalar._total_instances),
+                                                      vtype=uw.VarType.SCALAR, degree=degree, )
             
         self.Unknowns.u = u_Field
         self.Unknowns.DuDt = DuDt
@@ -939,7 +939,7 @@ class SNES_Vector(Solver):
         ## Todo: some validity checking on the size / type of u_Field supplied
         if not u_Field:
             self.Unknowns.u = uw.discretisation.MeshVariable( mesh=mesh, 
-                        num_components=mesh.dim, varname="Uv{}".format(self.instance_number),
+                        num_components=mesh.dim, varname="Uv{}".format(SNES_Vector._total_instances),
                         vtype=uw.VarType.VECTOR, degree=degree )
 
 
@@ -1518,8 +1518,9 @@ class SNES_Stokes_SaddlePt(Solver):
         ## Any problem with U,P, just define our own
         if velocityField == None or pressureField == None:
 
-            i = self.instance_number
-            self.Unknowns.u = uw.discretisation.MeshVariable(f"U{i}", self.mesh, self.mesh.dim, degree=degree, varsymbol=rf"{{\mathbf{{u}}^{{[{i}]}} }}" )
+            # Note, ensure names are unique for each solver type
+            i = SNES_Stokes_SaddlePt._total_instances
+            self.Unknowns.u = uw.discretisation.MeshVariable(f"V{i}", self.mesh, self.mesh.dim, degree=degree, varsymbol=rf"{{\mathbf{{u}}^{{[{i}]}} }}" )
             self.Unknowns.p = uw.discretisation.MeshVariable(f"P{i}", self.mesh, 1, degree=degree-1, continuous=p_continuous, varsymbol=rf"{{\mathbf{{p}}^{{[{i}]}} }}")
 
             if self.verbose and uw.mpi.rank == 0:

--- a/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -138,7 +138,18 @@ class Solver(uw_object):
 
         self.natural_bcs = []
         self.essential_bcs = []
-        self.dm = None
+
+        if self.snes is not None:
+            self.snes.destroy()
+            self.snes = None
+
+        if self.dm is not None:
+            for coarse_dm in self.dm_hierarchy:
+                coarse_dm.destroy()
+
+            self.dm = None
+            self.dm_hierarchy = [None]
+
         self._is_setup = False
 
         return
@@ -1030,7 +1041,6 @@ class SNES_Vector(Solver):
             bc_is = bc_label.getStratumIS(value)
             self.natural_bcs[index] = self.natural_bcs[index]._replace(boundary_label_val=value)
 
-
             # use type 5 bc for `DM_BC_ESSENTIAL_FIELD` enum
             # use type 6 bc for `DM_BC_NATURAL_FIELD` enum  
 
@@ -1306,10 +1316,6 @@ class SNES_Vector(Solver):
             for boundary in self.natural_bcs:
                 UW_PetscDSViewBdWF(ds.ds, boundary.PETScID)
 
-
-
-
-
         # Rebuild this lot
 
         for coarse_dm in self.dm_hierarchy:
@@ -1547,8 +1553,8 @@ class SNES_Stokes_SaddlePt(Solver):
         self._strategy = "default"
 
         self.petsc_options["snes_rtol"] = self._tolerance
-        self.petsc_options["snes_use_ew"] = None
-        self.petsc_options["snes_use_ew_version"] = 3
+        self.petsc_options["snes_ksp_ew"] = None
+        self.petsc_options["snes_ksp_ew_version"] = 3
 
         self.petsc_options["pc_type"] = "fieldsplit"
         self.petsc_options["pc_fieldsplit_type"] = "schur"
@@ -1680,8 +1686,8 @@ class SNES_Stokes_SaddlePt(Solver):
     def tolerance(self, value):
         self._tolerance = value
         self.petsc_options["snes_rtol"] = self._tolerance
-        self.petsc_options["snes_use_ew"] = None
-        self.petsc_options["snes_use_ew_version"] = 3
+        self.petsc_options["snes_ksp_ew"] = None
+        self.petsc_options["snes_ksp_ew_version"] = 3
 
         self.petsc_options["ksp_atol"]  = self._tolerance * 1.0e-6
         self.petsc_options["fieldsplit_pressure_ksp_rtol"]  = self._tolerance * 0.1  # rule of thumb
@@ -1699,8 +1705,8 @@ class SNES_Stokes_SaddlePt(Solver):
 
         # All strategies: reset to preferred
 
-        self.petsc_options["snes_use_ew"] = None
-        self.petsc_options["snes_use_ew_version"] = 3
+        self.petsc_options["snes_ksp_ew"] = None
+        self.petsc_options["snes_ksp_ew_version"] = 3
 
         self.petsc_options["pc_type"] = "fieldsplit"
         self.petsc_options["pc_fieldsplit_type"] = "schur"

--- a/underworld3/discretisation.py
+++ b/underworld3/discretisation.py
@@ -422,7 +422,7 @@ class Mesh(Stateful, uw_object):
             self.isSimplex,
             self.qdegree,
             "meshproj_{}_".format(self.mesh_instances),
-            PETSc.COMM_WORLD,
+            PETSc.COMM_SELF,
         )
 
         if PETSc.Sys.getVersion() <= (3, 20, 1):
@@ -982,7 +982,7 @@ class Mesh(Stateful, uw_object):
             self.isSimplex,
             self.qdegree,
             "coordinterp_",
-            PETSc.COMM_WORLD,
+            PETSc.COMM_SELF,
         )
 
         dmnew.setField(0, dmfe)
@@ -1795,7 +1795,7 @@ class _MeshVariable(Stateful, uw_object):
             self.mesh.isSimplex,
             self.mesh.qdegree,
             "coordinterp_",
-            PETSc.COMM_WORLD,
+            PETSc.COMM_SELF,
         )
 
         dmnew.setField(0, dmfe)
@@ -2028,7 +2028,7 @@ class _MeshVariable(Stateful, uw_object):
             self.mesh.isSimplex,
             self.mesh.qdegree,
             name0 + "_",
-            PETSc.COMM_WORLD,
+            PETSc.COMM_SELF,
         )
 
         self.field_id = self.mesh.dm.getNumFields()

--- a/underworld3/utilities/_api_tools.py
+++ b/underworld3/utilities/_api_tools.py
@@ -43,7 +43,14 @@ class counted_metaclass(type):
 
 class uw_object_counter(object, metaclass=counted_metaclass):
     def __init__(self):
+        try:
+            self.__class__.mro()[1]._total_instances += 1
+        except AttributeError:
+            pass
+            # print(f"{self.__class__.mro()[1]} is not a uw_object")
+
         super().__init__()
+
         self.__class__._total_instances += 1
         self.instance_number = self.__class__._total_instances
 

--- a/underworld3/utilities/_jitextension.py
+++ b/underworld3/utilities/_jitextension.py
@@ -49,7 +49,29 @@ def debugging_text(randstr, fn, fn_type, eqn_no):
     debug_str = f"/* {fn} */\n"
     debug_str += f"/* Size = {object_size} */\n"
     debug_str += f'FILE *fp; fp = fopen( "{randstr}_debug.txt", "a" );\n'
-    debug_str += f'fprintf(fp,"{fn_type} - equation {eqn_no} at (%6e, %6e, %.6e) -> ", petsc_x[0], petsc_x[1], dim==2 ? 0.0: petsc_x[2]);\n'
+    debug_str += f'fprintf(fp,"{fn_type} - equation {eqn_no} at (%.2e, %.2e, %.2e) -> ", petsc_x[0], petsc_x[1], dim==2 ? 0.0: petsc_x[2]);\n'
+    debug_str += f'fprintf(fp,"{formatstr}\\n", {outstr});\n'
+    debug_str += f"fclose(fp);"
+
+    return debug_str
+
+
+def debugging_text_bd(randstr, fn, fn_type, eqn_no):
+    try:
+        object_size = len(fn.flat())
+    except:
+        object_size = 1
+
+    outstr = "out[0]"
+    for i in range(1, object_size):
+        outstr += f", out[{i}]"
+
+    formatstr = "%6e, " * object_size
+
+    debug_str = f"/* {fn} */\n"
+    debug_str += f"/* Size = {object_size} */\n"
+    debug_str += f'FILE *fp; fp = fopen( "{randstr}_debug.txt", "a" );\n'
+    debug_str += f'fprintf(fp,"{fn_type} - equation {eqn_no} X / N (%.2e, %.2e, %.2e / %2.e, %2.e, %.2e ) -> ", petsc_x[0], petsc_x[1], dim==2 ? 0.0: petsc_x[2], petsc_n[0], petsc_n[1], dim==2 ? 0.0: petsc_n[2]);\n'
     debug_str += f'fprintf(fp,"{formatstr}\\n", {outstr});\n'
     debug_str += f"fclose(fp);"
 
@@ -524,7 +546,7 @@ cdef extern from "cy_ext.h" nogil:
     eqn_index_0 = eqn_index_1
     eqn_index_1 = eqn_index_1 + count_bd_residual_sig
     for eqn in eqns[eqn_index_0:eqn_index_1]:
-        debug_str = debugging_text(randstr, fns[fn_counter], "bdres", fn_counter)
+        debug_str = debugging_text_bd(randstr, fns[fn_counter], "bdres", fn_counter)
         h_str += "void {}_petsc_{}{}\n{{\n{}\n{}\n}}\n\n".format(
             randstr, eqn[0], bd_residual_sig, eqn[1], debug_str if debug else ""
         )
@@ -534,7 +556,7 @@ cdef extern from "cy_ext.h" nogil:
     eqn_index_0 = eqn_index_1
     eqn_index_1 = eqn_index_1 + count_bd_jacobian_sig
     for eqn in eqns[eqn_index_0:eqn_index_1]:
-        debug_str = debugging_text(randstr, fns[fn_counter], "bdjac", fn_counter)
+        debug_str = debugging_text_bd(randstr, fns[fn_counter], "bdjac", fn_counter)
         h_str += "void {}_petsc_{}{}\n{{\n{}\n{}\n}}\n\n".format(
             randstr, eqn[0], bd_jacobian_sig, eqn[1], debug_str if debug else ""
         )

--- a/underworld3/utilities/_utils.py
+++ b/underworld3/utilities/_utils.py
@@ -69,6 +69,8 @@ class CaptureStdout(UserString, redirect_stdout):
 
 # A couple of useful h5 tricks
 def h5_scan(filename):
+    import h5py
+
     h5file = h5py.File(filename)
     entities = []
     h5file.visit(entities.append)
@@ -134,7 +136,7 @@ def gather_data(val, bcast=False):
     comm.barrier()
 
     if bcast == True:
-        #### make swarm coords available on all processors
+        #### make available on all processors
         val_global = comm.bcast(val_global, root=0)
 
     comm.barrier()


### PR DESCRIPTION
Very silly (global v. local) bugs in the dm updates associated with new variables. Fixing for parallel solve() / mesh var ordering. This should help with meshes that need to make a solve as part of their setup (e.g. for the surface normals to be projected).

Update to use some new petsc option names. 
Examples with projected normals for irregular boundaries.
Comparisons of faceted normals, analytic normals, projected normals for several cases.

@julesghub - maybe merge this before the major restructure pull request as it will be hard to resolve PETSc conflicts in the merges otherwise. 

