### PR TITLE
Bc stacker

### DIFF
--- a/Jupyterbook/Notebooks/Examples-StokesFlow/Ex_Stokes_Cartesian_SolC.py
+++ b/Jupyterbook/Notebooks/Examples-StokesFlow/Ex_Stokes_Cartesian_SolC.py
@@ -64,7 +64,9 @@ x,y = mesh.X
 # -
 
 
-stokes = uw.systems.Stokes(mesh, verbose=False)
+mesh.view()
+
+stokes = uw.systems.Stokes(mesh, verbose=True)
 
 # +
 v = stokes.Unknowns.u

--- a/src/underworld3/adaptivity.py
+++ b/src/underworld3/adaptivity.py
@@ -33,6 +33,8 @@ def _dm_stack_bcs(dm, boundaries, stacked_bc_label_name):
     dm.createLabel(stacked_bc_label_name)
     stacked_bc_label = dm.getLabel(stacked_bc_label_name)
 
+    print(f"{uw.mpi.rank}: BC stacker - 1", flush=True)
+
     for b in boundaries:
         bc_label_name = b.name
         lab = dm.getLabel(bc_label_name)
@@ -40,10 +42,15 @@ def _dm_stack_bcs(dm, boundaries, stacked_bc_label_name):
         if not lab:
             continue
 
+        print(f"{uw.mpi.rank}: BC stacker - 2 ({b.name})", flush=True)
+
         lab_is = lab.getStratumIS(b.value)
 
         # Load this up on the stack
-        stacked_bc_label.setStratumIS(b.value, lab_is)
+        if lab_is:
+            stacked_bc_label.setStratumIS(b.value, lab_is)
+
+        print(f"{uw.mpi.rank}: BC stacker - 3 ({b.name})", flush=True)
 
 
 def _dm_unstack_bcs(dm, boundaries, stacked_bc_label_name):

--- a/src/underworld3/adaptivity.py
+++ b/src/underworld3/adaptivity.py
@@ -33,8 +33,6 @@ def _dm_stack_bcs(dm, boundaries, stacked_bc_label_name):
     dm.createLabel(stacked_bc_label_name)
     stacked_bc_label = dm.getLabel(stacked_bc_label_name)
 
-    print(f"{uw.mpi.rank}: BC stacker - 1", flush=True)
-
     for b in boundaries:
         bc_label_name = b.name
         lab = dm.getLabel(bc_label_name)
@@ -42,15 +40,11 @@ def _dm_stack_bcs(dm, boundaries, stacked_bc_label_name):
         if not lab:
             continue
 
-        print(f"{uw.mpi.rank}: BC stacker - 2 ({b.name})", flush=True)
-
         lab_is = lab.getStratumIS(b.value)
 
         # Load this up on the stack
         if lab_is:
             stacked_bc_label.setStratumIS(b.value, lab_is)
-
-        print(f"{uw.mpi.rank}: BC stacker - 3 ({b.name})", flush=True)
 
 
 def _dm_unstack_bcs(dm, boundaries, stacked_bc_label_name):

--- a/src/underworld3/cython/petsc_discretisation.pyx
+++ b/src/underworld3/cython/petsc_discretisation.pyx
@@ -80,6 +80,9 @@ def petsc_dm_create_submesh_from_label(incoming_dm, boundary_label_name, boundar
         return 
 
         
+
+# This is not cython, does it need to be here or in discretisation.py ?       
+
 def petsc_dm_find_labeled_points_local(dm, label_name, sectionIndex=False, verbose=False):
         '''Identify local points associated with "Label" 
         

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -2361,6 +2361,10 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
 
         if not zero_init_guess:
 
+            if verbose and uw.mpi.rank == 0:
+                print(f"SNES pre-solve - non-zero initial guess", flush=True)
+
+
             self.petsc_options.setValue("snes_max_it", 0)
             self.snes.setType("nrichardson")
             self.snes.setFromOptions()
@@ -2378,7 +2382,8 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         else:
             self.atol = 0.0
 
-        
+        if verbose and uw.mpi.rank == 0:
+            print(f"SNES solve - picard = {picard}", flush=True)
 
         # Picard solves if requested
 
@@ -2410,13 +2415,17 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         cdef Vec clvec
         cdef DM csdm
 
+        if verbose and uw.mpi.rank == 0:
+                print(f"SNES post-solve - bcs", flush=True)
+
+
         # Copy solution back into user facing variables 
 
         with self.mesh.access(self.Unknowns.p, self.Unknowns.u):
-            print(f"p: {self.Unknowns.p.name}, v: {self.Unknowns.u.name}")
+            # print(f"p: {self.Unknowns.p.name}, v: {self.Unknowns.u.name}")
 
             for name,var in self.fields.items():
-                print(f"{uw.mpi.rank}: Copy field {name} / {var.name} to user variables", flush=True)
+                # print(f"{uw.mpi.rank}: Copy field {name} / {var.name} to user variables", flush=True)
 
                 sgvec = gvec.getSubVector(self._subdict[name][0])  # Get global subvec off solution gvec.
 
@@ -2434,7 +2443,7 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
                 clvec = lvec
                 csdm = sdm
                 
-                print(f"{uw.mpi.rank}: Copy bcs for {name} to user variables", flush=True)
+                # print(f"{uw.mpi.rank}: Copy bcs for {name} to user variables", flush=True)
                 ierr = DMPlexSNESComputeBoundaryFEM(csdm.dm, <void*>clvec.vec, NULL); CHKERRQ(ierr)
 
                 # Now copy into the user vec.
@@ -2442,7 +2451,7 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
 
                 sdm.restoreLocalVec(lvec)
 
-                print(f"{uw.mpi.rank}: Copy field {name} / {var.name} ... done", flush=True)
+                # print(f"{uw.mpi.rank}: Copy field {name} / {var.name} ... done", flush=True)
 
 
         self.dm.restoreGlobalVec(gvec)

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -646,9 +646,9 @@ class SNES_Scalar(SolverBaseClass):
 
             bc_label = mesh.dm.getLabel(boundary)
             bc_is = bc_label.getStratumIS(value)
-            if bc_is is None:
-                print(f"{uw.mpi.rank}: Skip bc {boundary}", flush=True)
-                continue
+            # if bc_is is None:
+            #     print(f"{uw.mpi.rank}: Skip bc {boundary}", flush=True)
+            #     continue
 
             if bc.fn_f is not None:
 
@@ -1050,7 +1050,7 @@ class SNES_Vector(SolverBaseClass):
             bc = PetscDSAddBoundary_UW(cdm.dm, 
                                 bc_type, 
                                 str(boundary+f"{bc.components}").encode('utf8'), 
-                                str(boundary).encode('utf8'), 
+                                "UW_Boundaries".encode('utf8'),   # was: str(boundary)
                                 0,  # field ID in the DM
                                 num_constrained_components,
                                 <const PetscInt *> &comps_view[0], 
@@ -1084,7 +1084,7 @@ class SNES_Vector(SolverBaseClass):
             bc = PetscDSAddBoundary_UW(cdm.dm, 
                                 bc_type, 
                                 str(boundary+f"{bc.components}").encode('utf8'), 
-                                str(boundary).encode('utf8'), 
+                                "UW_Boundaries".encode('utf8'),   # was: str(boundary)
                                 0,  # field ID in the DM
                                 num_constrained_components,
                                 <const PetscInt *> &comps_view[0], 
@@ -1272,7 +1272,8 @@ class SNES_Vector(SolverBaseClass):
             boundary_id = bc.PETScID
             
             value = self.mesh.boundaries[bc.boundary].value
-            bc_label = self.dm.getLabel(boundary)
+            bc_label = self.dm.getLabel("UW_Boundaries")
+            #bc_label = self.dm.getLabel(boundary)
             
             label_val = value            
 
@@ -2092,9 +2093,9 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
             value = mesh.boundaries[bc.boundary].value
             ind = value
 
-            bc_label = self.dm.getLabel(boundary)
-            bc_is = bc_label.getStratumIS(value)
-            self.natural_bcs[index] = self.natural_bcs[index]._replace(boundary_label_val=value)
+            # bc_label = self.dm.getLabel(boundary)
+            # bc_is = bc_label.getStratumIS(value)
+            # self.natural_bcs[index] = self.natural_bcs[index]._replace(boundary_label_val=value)
 
             # use type 5 bc for `DM_BC_ESSENTIAL_FIELD` enum
             # use type 6 bc for `DM_BC_NATURAL_FIELD` enum  
@@ -2105,7 +2106,7 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
             bc = PetscDSAddBoundary_UW(cdm.dm, 
                                 bc_type, 
                                 str(boundary+f"{bc.components}").encode('utf8'), 
-                                str(boundary).encode('utf8'), 
+                                str("UW_Boundaries").encode('utf8'), 
                                 0,  # field ID in the DM
                                 num_constrained_components,
                                 <const PetscInt *> &comps_view[0], 
@@ -2197,7 +2198,8 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
             boundary_id = bc.PETScID
             
             value = self.mesh.boundaries[bc.boundary].value
-            bc_label = self.dm.getLabel(boundary)
+            bc_label = self.dm.getLabel("UW_Boundaries")
+            # bc_label = self.dm.getLabel(boundary)
             
             label_val = value            
 

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -2418,7 +2418,6 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         if verbose and uw.mpi.rank == 0:
                 print(f"SNES post-solve - bcs", flush=True)
 
-
         # Copy solution back into user facing variables 
 
         with self.mesh.access(self.Unknowns.p, self.Unknowns.u):
@@ -2450,7 +2449,6 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
                 var.vec.array[:] = lvec.array[:]
 
                 sdm.restoreLocalVec(lvec)
-
                 # print(f"{uw.mpi.rank}: Copy field {name} / {var.name} ... done", flush=True)
 
 

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -2413,10 +2413,10 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         # Copy solution back into user facing variables 
 
         with self.mesh.access(self.Unknowns.p, self.Unknowns.u):
-            # print(f"p: {self.Unknowns.p.name}, v: {self.Unknowns.u.name}")
+            print(f"p: {self.Unknowns.p.name}, v: {self.Unknowns.u.name}")
 
             for name,var in self.fields.items():
-                # print(f"{uw.mpi.rank}: Copy field {name} / {var.name} to user variables", flush=True)
+                print(f"{uw.mpi.rank}: Copy field {name} / {var.name} to user variables", flush=True)
 
                 sgvec = gvec.getSubVector(self._subdict[name][0])  # Get global subvec off solution gvec.
 
@@ -2434,7 +2434,7 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
                 clvec = lvec
                 csdm = sdm
                 
-                # print(f"{uw.mpi.rank}: Copy bcs for {name} to user variables", flush=True)
+                print(f"{uw.mpi.rank}: Copy bcs for {name} to user variables", flush=True)
                 ierr = DMPlexSNESComputeBoundaryFEM(csdm.dm, <void*>clvec.vec, NULL); CHKERRQ(ierr)
 
                 # Now copy into the user vec.
@@ -2442,7 +2442,7 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
 
                 sdm.restoreLocalVec(lvec)
 
-                # print(f"{uw.mpi.rank}: Copy field {name} / {var.name} ... done", flush=True)
+                print(f"{uw.mpi.rank}: Copy field {name} / {var.name} ... done", flush=True)
 
 
         self.dm.restoreGlobalVec(gvec)

--- a/src/underworld3/discretisation.py
+++ b/src/underworld3/discretisation.py
@@ -394,15 +394,6 @@ class Mesh(Stateful, uw_object):
 
         ## Boundary information
 
-        # for bd in self.boundaries:
-        #     l = self.dm.getLabel(bd.name)
-        #     if l:
-        #         i = l.getStratumSize(2)
-        #         ii = uw.utilities.gather_data(np.array([float(i)])).astype(int)
-        #         uw.mpi.barrier()
-        #     else:
-        #         ii = np.array([0])
-
         if uw.mpi.rank == 0:
             if len(self.boundaries) > 0:
                 print(f"| Boundary Name            | ID    | Min Size | Max Size |")
@@ -417,11 +408,11 @@ class Mesh(Stateful, uw_object):
             else:
                 i = 0
 
-            ii = uw.utilities.gather_data(np.array([float(i)]))
+            ii = uw.utilities.gather_data(np.array([i]), dtype="int")
 
             if uw.mpi.rank == 0:
                 print(
-                    f"| {bd.name:<20}     | {bd.value:<5} | {int(ii.min()):<8} | {int(ii.max()):<8} |",
+                    f"| {bd.name:<20}     | {bd.value:<5} | {ii.min():<8} | {ii.max():<8} |",
                 )
 
         if uw.mpi.rank == 0:
@@ -1351,6 +1342,31 @@ class Mesh(Stateful, uw_object):
         vrms = vnorm2 / numpy.sqrt(vsize)
 
         return vsize, vmean, vmin, vmax, vsum, vnorm2, vrms
+
+    def meshVariable_mask_from_label(self, label_name, label_value):
+        """Extract single label value and make a point mask"""
+
+        meshVar = MeshVariable(
+            f"Mask_{label_name}",
+            self,
+            vtype=uw.VarType.SCALAR,
+            degree=1,
+            continuous=True,
+            varsymbol=rf"\cal{{M}}^{{[{label_name:.4}]}}",
+        )
+
+        point_indices = petsc_dm_find_labeled_points_local(
+            self.dm,
+            label_name,
+            label_value,
+            sectionIndex=False,
+        )
+
+        with self.access(meshVar):
+            meshVar.data[...] = 0.0
+            meshVar.data[point_indices] = 1.0
+
+        return meshVar
 
 
 ## Here we check the existence of the meshVariable and so on before defining a new one
@@ -2507,3 +2523,78 @@ def meshVariable_lookup_by_symbol(mesh, sympy_object):
                     return meshvar, comp
 
     return None
+
+
+def petsc_dm_find_labeled_points_local(
+    dm, label_name, label_value, sectionIndex=False, verbose=False
+):
+    """Identify local points associated with "Label"
+
+    dm -> expects a petscDM object
+    label_name -> "String Name for Label"
+    sectionIndex -> False: leave points as indexed by the relevant section on the dm
+                    True: index into the local coordinate array
+
+    NOTE: Assumes uniform element types
+    """
+
+    import numpy as np
+
+    pStart, pEnd = dm.getDepthStratum(0)
+    eStart, eEnd = dm.getDepthStratum(1)
+    fStart, fEnd = dm.getDepthStratum(2)
+
+    print(f"Label: {label_name} / {label_value}")
+    print(f"points: {pStart}: {pEnd}")
+    print(f"edges : {eStart}: {eEnd}")
+    print(f"faces : {fStart}: {fEnd}")
+    print(f"", flush=True)
+
+    label = dm.getLabel(label_name)
+    if not label:
+        if uw.mpi.rank == 0:
+            print(f"Label {label_name} is not present on the dm")
+        return np.array([0])
+
+    pointIS = dm.getStratumIS("depth", 0)
+    edgeIS = dm.getStratumIS("depth", 1)
+    faceIS = dm.getStratumIS("depth", 2)
+
+    point_indices = pointIS.getIndices()
+    edge_indices = edgeIS.getIndices()
+    face_indices = faceIS.getIndices()
+
+    # _, iset_lab = label.convertToSection()
+    iset_lab = label.getStratumIS(label_value)
+
+    # We need to associate edges and faces with their point indices to
+    # build a field representation
+
+    IndicesP = np.intersect1d(iset_lab.getIndices(), pointIS.getIndices())
+    IndicesE = np.intersect1d(iset_lab.getIndices(), edgeIS.getIndices())
+    IndicesF = np.intersect1d(iset_lab.getIndices(), faceIS.getIndices())
+
+    # print(f"Label {label_name}")
+    # print(f"P -> {len(IndicesP)}, E->{len(IndicesE)}, F->{len(IndicesF)},")
+
+    IndicesFe = np.empty((IndicesF.shape[0], dm.getConeSize(fStart)), dtype=int)
+    for f in range(IndicesF.shape[0]):
+        IndicesFe[f] = dm.getCone(IndicesF[f])
+
+    IndicesFE = np.union1d(IndicesE, IndicesFe)
+
+    # All faces are now recorded as edges
+
+    IndicesFEP = np.empty((IndicesFE.shape[0], dm.getConeSize(eStart)), dtype=int)
+
+    for e in range(IndicesFE.shape[0]):
+        IndicesFEP[e] = dm.getCone(IndicesFE[e])
+
+    # all faces / edges are now points
+
+    if sectionIndex:
+        Indices = np.union1d(IndicesP, IndicesFEP)
+    else:
+        Indices = np.union1d(IndicesP, IndicesFEP) - pStart
+
+    return Indices

--- a/src/underworld3/discretisation.py
+++ b/src/underworld3/discretisation.py
@@ -1347,7 +1347,7 @@ class Mesh(Stateful, uw_object):
         """Extract single label value and make a point mask"""
 
         meshVar = MeshVariable(
-            f"Mask_{label_name}",
+            f"Mask_{label_name}_{label_value}",
             self,
             vtype=uw.VarType.SCALAR,
             degree=1,

--- a/src/underworld3/discretisation.py
+++ b/src/underworld3/discretisation.py
@@ -2566,6 +2566,8 @@ def petsc_dm_find_labeled_points_local(
 
     # _, iset_lab = label.convertToSection()
     iset_lab = label.getStratumIS(label_value)
+    if not iset_lab:
+        return np.zeros((0, 0))
 
     # We need to associate edges and faces with their point indices to
     # build a field representation

--- a/src/underworld3/discretisation.py
+++ b/src/underworld3/discretisation.py
@@ -941,6 +941,9 @@ class Mesh(Stateful, uw_object):
 
         viewer(self.dm)
 
+        # Not sure if the files are correctly written if we do not explicitly destroy the viewer
+        viewer.destroy()
+
     def vtk(self, filename: str):
         """
         Save mesh to the specified file
@@ -948,6 +951,7 @@ class Mesh(Stateful, uw_object):
 
         viewer = PETSc.Viewer().createVTK(filename, "w", comm=PETSc.COMM_WORLD)
         viewer(self.dm)
+        viewer.destroy()
 
     def generate_xdmf(self, filename: str):
         """

--- a/src/underworld3/discretisation.py
+++ b/src/underworld3/discretisation.py
@@ -1364,7 +1364,8 @@ class Mesh(Stateful, uw_object):
 
         with self.access(meshVar):
             meshVar.data[...] = 0.0
-            meshVar.data[point_indices] = 1.0
+            if point_indices is not None:
+                meshVar.data[point_indices] = 1.0
 
         return meshVar
 
@@ -2567,7 +2568,7 @@ def petsc_dm_find_labeled_points_local(
     # _, iset_lab = label.convertToSection()
     iset_lab = label.getStratumIS(label_value)
     if not iset_lab:
-        return np.zeros((0, 0))
+        return None
 
     # We need to associate edges and faces with their point indices to
     # build a field representation

--- a/src/underworld3/discretisation.py
+++ b/src/underworld3/discretisation.py
@@ -2545,11 +2545,11 @@ def petsc_dm_find_labeled_points_local(
     eStart, eEnd = dm.getDepthStratum(1)
     fStart, fEnd = dm.getDepthStratum(2)
 
-    print(f"Label: {label_name} / {label_value}")
-    print(f"points: {pStart}: {pEnd}")
-    print(f"edges : {eStart}: {eEnd}")
-    print(f"faces : {fStart}: {fEnd}")
-    print(f"", flush=True)
+    # print(f"Label: {label_name} / {label_value}")
+    # print(f"points: {pStart}: {pEnd}")
+    # print(f"edges : {eStart}: {eEnd}")
+    # print(f"faces : {fStart}: {fEnd}")
+    # print(f"", flush=True)
 
     label = dm.getLabel(label_name)
     if not label:

--- a/src/underworld3/discretisation.py
+++ b/src/underworld3/discretisation.py
@@ -196,6 +196,8 @@ class Mesh(Stateful, uw_object):
         self.boundaries = boundaries
         self.boundary_normals = boundary_normals
 
+        uw.adaptivity._dm_stack_bcs(self.dm, self.boundaries, "UW_Boundaries")
+
         self.refinement_callback = refinement_callback
         self.return_coords_to_bounds = return_coords_to_bounds
         self.name = name

--- a/src/underworld3/meshing.py
+++ b/src/underworld3/meshing.py
@@ -1281,7 +1281,6 @@ def AnnulusInternalBoundary(
         Centre = 10
         All_Boundaries = 1001
 
-
     if cellSize_Inner is None:
         cellSize_Inner = cellSize
 
@@ -1493,7 +1492,6 @@ def CubedSphere(
         Lower = 1
         Upper = 2
         All_Boundaries = 1001
-
 
     r1 = radiusInner / np.sqrt(3)
     r2 = radiusOuter / np.sqrt(3)
@@ -1713,7 +1711,6 @@ def RegionalSphericalBox(
         East = 5
         West = 6
         All_Boundaries = 1001
-
 
     r1 = radiusInner / np.sqrt(3)
     r2 = radiusOuter / np.sqrt(3)
@@ -2092,7 +2089,6 @@ def SegmentedSphericalShell(
         Centre = 1
         Slices = 40
         All_Boundaries = 1001
-
 
     meshRes = cellSize
     num_segments = numSegments
@@ -2494,7 +2490,6 @@ def SegmentedSphericalBall(
         Centre = 1
         Slices = 40
         All_Boundaries = 1001
-
 
     meshRes = cellSize
     num_segments = numSegments

--- a/src/underworld3/meshing.py
+++ b/src/underworld3/meshing.py
@@ -48,6 +48,7 @@ def UnstructuredSimplexBox(
         Top = 12
         Right = 13
         Left = 14
+        All_Boundaries = 1001
 
     class boundaries_3D(Enum):
         Bottom = 11
@@ -56,6 +57,7 @@ def UnstructuredSimplexBox(
         Left = 14
         Front = 15
         Back = 16
+        All_Boundaries = 1001
 
     # Enum is not quite natural but matches the above
 
@@ -256,6 +258,7 @@ def StructuredQuadBox(
         Top = 12
         Right = 13
         Left = 14
+        All_Boundaries = 1001
 
     class boundaries_3D(Enum):
         Bottom = 11
@@ -264,6 +267,7 @@ def StructuredQuadBox(
         Left = 14
         Front = 15
         Back = 16
+        All_Boundaries = 1001
 
     # Enum is not quite natural but matches the above
 
@@ -524,6 +528,7 @@ def SphericalShell(
         Lower = 11
         Upper = 12
         Centre = 1
+        All_Boundaries = 1001
 
     import gmsh
 
@@ -677,6 +682,7 @@ def QuarterAnnulus(
         Left = 3
         Right = 4
         Centre = 10
+        All_Boundaries = 1001
 
     if filename is None:
         if uw.mpi.rank == 0:
@@ -843,6 +849,7 @@ def Annulus(
         Lower = 1
         Upper = 2
         Centre = 10
+        All_Boundaries = 1001
 
     if filename is None:
         if uw.mpi.rank == 0:
@@ -1015,6 +1022,7 @@ def AnnulusWithSpokes(
         UpperPlus = 21
         Centre = 1
         Spokes = 99
+        All_Boundaries = 1001
 
     if filename is None:
         if uw.mpi.rank == 0:
@@ -1271,6 +1279,8 @@ def AnnulusInternalBoundary(
         Internal = 2
         Upper = 3
         Centre = 10
+        All_Boundaries = 1001
+
 
     if cellSize_Inner is None:
         cellSize_Inner = cellSize
@@ -1482,6 +1492,8 @@ def CubedSphere(
     class boundaries(Enum):
         Lower = 1
         Upper = 2
+        All_Boundaries = 1001
+
 
     r1 = radiusInner / np.sqrt(3)
     r2 = radiusOuter / np.sqrt(3)
@@ -1700,6 +1712,8 @@ def RegionalSphericalBox(
         South = 4
         East = 5
         West = 6
+        All_Boundaries = 1001
+
 
     r1 = radiusInner / np.sqrt(3)
     r2 = radiusOuter / np.sqrt(3)
@@ -2077,6 +2091,8 @@ def SegmentedSphericalShell(
         UpperPlus = 31
         Centre = 1
         Slices = 40
+        All_Boundaries = 1001
+
 
     meshRes = cellSize
     num_segments = numSegments
@@ -2477,6 +2493,8 @@ def SegmentedSphericalBall(
         UpperPlus = 31
         Centre = 1
         Slices = 40
+        All_Boundaries = 1001
+
 
     meshRes = cellSize
     num_segments = numSegments

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -1872,7 +1872,7 @@ class NodalPointSwarm(Swarm):
 
         # Move slightly within the chosen cell to avoid edge effects
         centroid_coords = self.mesh._centroids[cellid]
-        shift = 1.0e-6
+        shift = 0.0
         coords[...] = (1.0 - shift) * coords[...] + shift * centroid_coords[...]
 
         nswarm.dm.restoreField("DMSwarmPIC_coor")

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -1966,14 +1966,12 @@ class NodalPointSwarm(Swarm):
                             V_fn_matrix[d], self.data
                         ).reshape(-1)
 
-                print(f"A: {uw.mpi.rank}: {bc_mask_fn}", flush=True)
-
-                bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data)).reshape(
-                    -1, 1
-                )
+                bc_mask_array = np.rint(
+                    uw.function.evalf(bc_mask_fn, self.data)
+                ).reshape(-1, 1)
 
                 mid_pt_coords = (
-                    self.data[...].copy() + 0.5 * delta_t * v_at_Vpts * bc_mask_fn
+                    self.data[...].copy() + 0.5 * delta_t * v_at_Vpts * bc_mask_array
                 )
 
                 # validate_coords to ensure they live within the domain (or there will be trouble)
@@ -2004,12 +2002,10 @@ class NodalPointSwarm(Swarm):
                 # if (uw.mpi.rank == 0):
                 #     print("Re-launch from X0", flush=True)
 
-                print(f"B: {uw.mpi.rank}: {bc_mask_fn}", flush=True)
-
-                bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data)).reshape(
-                    -1, 1
-                )
-                new_coords = X0.data[...].copy() + delta_t * v_at_Vpts * bc_mask_fn
+                bc_mask_array = np.rint(
+                    uw.function.evalf(bc_mask_fn, self.data)
+                ).reshape(-1, 1)
+                new_coords = X0.data[...].copy() + delta_t * v_at_Vpts * bc_mask_array
 
                 # validate_coords to ensure they live within the domain (or there will be trouble)
                 if restore_points_to_domain_func is not None:
@@ -2042,10 +2038,10 @@ class NodalPointSwarm(Swarm):
                             V_fn_matrix[d], self.data
                         ).reshape(-1)
 
-                bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data)).reshape(
-                    -1, 1
-                )
-                new_coords = self.data + delta_t * v_at_Vpts * bc_mask_fn
+                bc_mask_array = np.rint(
+                    uw.function.evalf(bc_mask_fn, self.data)
+                ).reshape(-1, 1)
+                new_coords = self.data + delta_t * v_at_Vpts * bc_mask_array
 
                 # validate_coords to ensure they live within the domain (or there will be trouble)
 

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -1966,7 +1966,9 @@ class NodalPointSwarm(Swarm):
                             V_fn_matrix[d], self.data
                         ).reshape(-1)
 
-                bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data))
+                bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data)).reshape(
+                    -1, 1
+                )
 
                 mid_pt_coords = (
                     self.data[...].copy() + 0.5 * delta_t * v_at_Vpts * bc_mask_fn
@@ -2000,7 +2002,9 @@ class NodalPointSwarm(Swarm):
                 # if (uw.mpi.rank == 0):
                 #     print("Re-launch from X0", flush=True)
 
-                bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data))
+                bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data)).reshape(
+                    -1, 1
+                )
                 new_coords = X0.data[...].copy() + delta_t * v_at_Vpts * bc_mask_fn
 
                 # validate_coords to ensure they live within the domain (or there will be trouble)
@@ -2034,6 +2038,9 @@ class NodalPointSwarm(Swarm):
                             V_fn_matrix[d], self.data
                         ).reshape(-1)
 
+                bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data)).reshape(
+                    -1, 1
+                )
                 new_coords = self.data + delta_t * v_at_Vpts * bc_mask_fn
 
                 # validate_coords to ensure they live within the domain (or there will be trouble)

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -1872,7 +1872,7 @@ class NodalPointSwarm(Swarm):
 
         # Move slightly within the chosen cell to avoid edge effects
         centroid_coords = self.mesh._centroids[cellid]
-        shift = 1.0e-3
+        shift = 0.0
         coords[...] = (1.0 - shift) * coords[...] + shift * centroid_coords[...]
 
         nswarm.dm.restoreField("DMSwarmPIC_coor")
@@ -1910,11 +1910,6 @@ class NodalPointSwarm(Swarm):
         # ? how does this interact with the particle restoration function ?
 
         V_fn_matrix = self.mesh.vector.to_matrix(V_fn)
-
-        with self.access():
-            bc_mask_fn = np.rint(
-                uw.function.evalf(bc_mask_fn, self.data).reshape(-1, 1)
-            )
 
         # if corrector == True and not self._X0_uninitialised:
         #     with self.access(self.particle_coordinates):
@@ -1971,6 +1966,8 @@ class NodalPointSwarm(Swarm):
                             V_fn_matrix[d], self.data
                         ).reshape(-1)
 
+                bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data))
+
                 mid_pt_coords = (
                     self.data[...].copy() + 0.5 * delta_t * v_at_Vpts * bc_mask_fn
                 )
@@ -2003,6 +2000,7 @@ class NodalPointSwarm(Swarm):
                 # if (uw.mpi.rank == 0):
                 #     print("Re-launch from X0", flush=True)
 
+                bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data))
                 new_coords = X0.data[...].copy() + delta_t * v_at_Vpts * bc_mask_fn
 
                 # validate_coords to ensure they live within the domain (or there will be trouble)

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -1966,6 +1966,8 @@ class NodalPointSwarm(Swarm):
                             V_fn_matrix[d], self.data
                         ).reshape(-1)
 
+                print(f"A: {uw.mpi.rank}: {bc_mask_fn}", flush=True)
+
                 bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data)).reshape(
                     -1, 1
                 )
@@ -2002,7 +2004,7 @@ class NodalPointSwarm(Swarm):
                 # if (uw.mpi.rank == 0):
                 #     print("Re-launch from X0", flush=True)
 
-                print(f"{uw.mpi.rank}: {bc_mask_fn}")
+                print(f"B: {uw.mpi.rank}: {bc_mask_fn}", flush=True)
 
                 bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data)).reshape(
                     -1, 1

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -2002,6 +2002,8 @@ class NodalPointSwarm(Swarm):
                 # if (uw.mpi.rank == 0):
                 #     print("Re-launch from X0", flush=True)
 
+                print(f"{uw.mpi.rank}: {bc_mask_fn}")
+
                 bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data)).reshape(
                     -1, 1
                 )

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -1872,7 +1872,7 @@ class NodalPointSwarm(Swarm):
 
         # Move slightly within the chosen cell to avoid edge effects
         centroid_coords = self.mesh._centroids[cellid]
-        shift = 1.0e-3
+        shift = 1.0e-2
         coords[...] = (1.0 - shift) * coords[...] + shift * centroid_coords[...]
 
         nswarm.dm.restoreField("DMSwarmPIC_coor")

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -1895,7 +1895,7 @@ class NodalPointSwarm(Swarm):
         order=2,
         corrector=False,
         restore_points_to_domain_func=None,
-        bc_mask_fn=None,
+        bc_mask_fn=sympy.sympify(1),
         evalf=False,
     ):
         # X0 holds the particle location at the start of advection

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -1872,7 +1872,7 @@ class NodalPointSwarm(Swarm):
 
         # Move slightly within the chosen cell to avoid edge effects
         centroid_coords = self.mesh._centroids[cellid]
-        shift = 0.0
+        shift = 1.0e-3
         coords[...] = (1.0 - shift) * coords[...] + shift * centroid_coords[...]
 
         nswarm.dm.restoreField("DMSwarmPIC_coor")

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -1911,7 +1911,8 @@ class NodalPointSwarm(Swarm):
 
         V_fn_matrix = self.mesh.vector.to_matrix(V_fn)
 
-        bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data).reshape(-1))
+        with self.access():
+            bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data).reshape(-1))
 
         # if corrector == True and not self._X0_uninitialised:
         #     with self.access(self.particle_coordinates):

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -1887,651 +1887,157 @@ class NodalPointSwarm(Swarm):
 
         return
 
-
-# class SemiLagrange_D_Dt(uw_object):
-#     r"""Nodal-Swarm  Lagrangian History Manager:
-#     This manages the update of a Lagrangian variable, $\psi$ on the swarm across timesteps.
-#     $$\quad \psi_p^{t-n\Delta t} \leftarrow \psi_p^{t-(n-1)\Delta t}\quad$$
-#     $$\quad \psi_p^{t-(n-1)\Delta t} \leftarrow \psi_p^{t-(n-2)\Delta t} \cdots\quad$$
-#     $$\quad \psi_p^{t-\Delta t} \leftarrow \psi_p^{t}$$
-#     """
-
-#     @timing.routine_timer_decorator
-#     def __init__(
-#         self,
-#         mesh: uw.discretisation.Mesh,
-#         psi_fn: sympy.Function,
-#         V_fn: sympy.Function,
-#         vtype: uw.VarType,
-#         degree: int,
-#         continuous: bool,
-#         varsymbol: Optional[str] = r"u",
-#         verbose: Optional[bool] = False,
-#         bcs=[],
-#         order=1,
-#         smoothing=0.0,
-#     ):
-#         super().__init__()
-
-#         self.mesh = mesh
-#         self.bcs = bcs
-#         self.verbose = verbose
-#         self.degree = degree
-
-#         # meshVariables are required for:
-#         #
-#         # u(t) - evaluation of u_fn at the current time
-#         # u*(t) - u_* evaluated from
-
-#         # psi is evaluated/stored at `order` timesteps. We can't
-#         # be sure if psi is a meshVariable or a function to be evaluated
-#         # psi_star is reaching back through each evaluation and has to be a
-#         # meshVariable (storage)
-
-#         self._psi_fn = psi_fn
-#         self.V_fn = V_fn
-#         self.order = order
-
-#         psi_star = []
-#         self.psi_star = psi_star
-
-#         for i in range(order):
-#             self.psi_star.append(
-#                 uw.discretisation.MeshVariable(
-#                     f"psi_star_sl_{self.instance_number}_{i}",
-#                     self.mesh,
-#                     vtype=vtype,
-#                     degree=degree,
-#                     continuous=continuous,
-#                     varsymbol=rf"{varsymbol}^{{ {'*'*(i+1)} }}",
-#                 )
-#             )
-
-#         # We just need one swarm since this is inherently a sequential operation
-#         nswarm = uw.swarm.NodalPointSwarm(self.psi_star[0])
-#         self._nswarm_psi = nswarm
-
-#         # The projection operator for mapping swarm values to the mesh - needs to be different for
-#         # each variable type, unfortunately ...
-
-#         if vtype == uw.VarType.SCALAR:
-#             self._psi_star_projection_solver = uw.systems.solvers.SNES_Projection(
-#                 self.mesh, self.psi_star[0], verbose=False
-#             )
-#         elif vtype == uw.VarType.VECTOR:
-#             self._psi_star_projection_solver = (
-#                 uw.systems.solvers.SNES_Vector_Projection(
-#                     self.mesh, self.psi_star[0], verbose=False
-#                 )
-#             )
-#         elif vtype == uw.VarType.SYM_TENSOR or vtype == uw.VarType.TENSOR:
-#             self._WorkVar = uw.discretisation.MeshVariable(
-#                 f"W_star_slcn_{self.instance_number}",
-#                 self.mesh,
-#                 vtype=uw.VarType.SCALAR,
-#                 degree=degree,
-#                 continuous=continuous,
-#                 varsymbol=r"W^{*}",
-#             )
-#             self._psi_star_projection_solver = (
-#                 uw.systems.solvers.SNES_Tensor_Projection(
-#                     self.mesh, self.psi_star[0], self._WorkVar, verbose=False
-#                 )
-#             )
-
-#         self._psi_star_projection_solver.uw_function = self.psi_fn
-#         self._psi_star_projection_solver.bcs = bcs
-#         self._psi_star_projection_solver.smoothing = smoothing
-
-#         return
-
-#     @property
-#     def psi_fn(self):
-#         return self._psi_fn
-
-#     @psi_fn.setter
-#     def psi_fn(self, new_fn):
-#         self._psi_fn = new_fn
-#         self._psi_star_projection_solver.uw_function = self._psi_fn
-#         return
-
-#     def _object_viewer(self):
-#         from IPython.display import Latex, Markdown, display
-
-#         super()._object_viewer()
-
-#         ## feedback on this instance
-#         # display(Latex(r"$\quad\psi = $ " + self.psi._repr_latex_()))
-#         # display(
-#         #     Latex(
-#         #         r"$\quad\Delta t_{\textrm{phys}} = $ "
-#         #         + sympy.sympify(self.dt_physical)._repr_latex_()
-#         #     )
-#         # )
-#         display(Latex(rf"$\quad$History steps = {self.order}"))
-
-#     def update(
-#         self,
-#         dt: float,
-#         evalf: Optional[bool] = False,
-#         verbose: Optional[bool] = False,
-#     ):
-#         self.update_pre_solve(dt, evalf, verbose)
-#         return
-
-#     def update_post_solve(
-#         self,
-#         dt: float,
-#         evalf: Optional[bool] = False,
-#         verbose: Optional[bool] = False,
-#     ):
-#         return
-
-#     def update_pre_solve(
-#         self,
-#         dt: float,
-#         evalf: Optional[bool] = False,
-#         verbose: Optional[bool] = False,
-#     ):
-#         # if average_over_dt:
-#         #     phi = min(1.0, dt / self.dt_physical)
-#         # else:
-#         #     phi = 1.0
-
-#         if verbose and uw.mpi.rank == 0:
-#             print(f"Update {self.psi_fn}", flush=True)
-
-#         ## Progress from the oldest part of the history
-#         # 1. Copy the stored values down the chain
-
-#         for i in range(self.order - 1, 0, -1):
-#             with self.mesh.access(self.psi_star[i]):
-#                 self.psi_star[i].data[...] = self.psi_star[i - 1].data[...]
-
-#         # 2. Compute the upstream values
-
-#         # We use the u_star variable as a working value here so we have to work backwards
-#         for i in range(self.order - 1, -1, -1):
-#             with self._nswarm_psi.access(self._nswarm_psi._X0):
-#                 self._nswarm_psi._X0.data[...] = self._nswarm_psi.data[...]
-
-#             # march nodes backwards along characteristics
-#             self._nswarm_psi.advection(
-#                 self.V_fn,
-#                 -dt,
-#                 order=2,
-#                 corrector=False,
-#                 restore_points_to_domain_func=self.mesh.return_coords_to_bounds,
-#             )
-
-#             if i == 0:
-#                 # Recalculate u_star from u_fn
-#                 self._psi_star_projection_solver.uw_function = self.psi_fn
-#                 self._psi_star_projection_solver.solve()
-
-#             with self._nswarm_psi.access(self._nswarm_psi.swarmVariable):
-#                 for d in range(self.psi_star[i].shape[1]):
-#                     self._nswarm_psi.swarmVariable.data[:, d] = uw.function.evaluate(
-#                         self.psi_star[i].sym[d], self._nswarm_psi.data
-#                     )
-
-#             # restore coords (will call dm.migrate after context manager releases)
-#             with self._nswarm_psi.access(self._nswarm_psi.particle_coordinates):
-#                 self._nswarm_psi.data[...] = self._nswarm_psi._X0.data[...]
-
-#             # Now project to the mesh using bc's to obtain u_star
-#             self._psi_star_projection_solver.uw_function = (
-#                 self._nswarm_psi.swarmVariable.sym
-#             )
-#             self._psi_star_projection_solver.solve()
-
-#             # Copy data from the projection operator if required
-#             if i != 0:
-#                 with self.mesh.access(self.psi_star[i]):
-#                     self.psi_star[i].data[...] = self.psi_star[0].data[...]
-
-#         return
-
-#     def bdf(self, order=None):
-#         r"""Backwards differentiation form for calculating DuDt
-#         Note that you will need `bdf` / $\delta t$ in computing derivatives"""
-
-#         if order is None:
-#             order = self.order
-#         else:
-#             order = max(1, min(self.order, order))
-
-#         with sympy.core.evaluate(False):
-#             if order == 1:
-#                 bdf0 = self.psi_fn - self.psi_star[0].sym
-
-#             elif order == 2:
-#                 bdf0 = (
-#                     3 * self.psi_fn / 2
-#                     - 2 * self.psi_star[0].sym
-#                     + self.psi_star[1].sym / 2
-#                 )
-
-#             elif order == 3:
-#                 bdf0 = (
-#                     11 * self.psi_fn / 6
-#                     - 3 * self.psi_star[0].sym
-#                     + 3 * self.psi_star[1].sym / 2
-#                     - self.psi_star[2].sym / 3
-#                 )
-
-#         return bdf0
-
-#     def adams_moulton_flux(self, order=None):
-#         if order is None:
-#             order = self.order
-#         else:
-#             order = max(1, min(self.order, order))
-
-#         with sympy.core.evaluate(False):
-#             if order == 1:
-#                 am = (self.psi_fn + self.psi_star[0].sym) / 2
-
-#             elif order == 2:
-#                 am = (
-#                     5 * self.psi_fn + 8 * self.psi_star[0].sym - self.psi_star[1].sym
-#                 ) / 12
-
-#             elif order == 3:
-#                 am = (
-#                     9 * self.psi_fn
-#                     + 19 * self.psi_star[0].sym
-#                     - 5 * self.psi_star[1].sym
-#                     + self.psi_star[2].sym
-#                 ) / 24
-
-#         return am
-
-
-# class Lagrangian_D_Dt(uw_object):
-#     r"""Swarm-based Lagrangian History Manager:
-
-#     This manages the update of a Lagrangian variable, $\psi$ on the swarm across timesteps.
-
-#     $\quad \psi_p^{t-n\Delta t} \leftarrow \psi_p^{t-(n-1)\Delta t}\quad$
-
-#     $\quad \psi_p^{t-(n-1)\Delta t} \leftarrow \psi_p^{t-(n-2)\Delta t} \cdots\quad$
-
-#     $\quad \psi_p^{t-\Delta t} \leftarrow \psi_p^{t}$
-#     """
-
-#     instances = 0  # count how many of these there are in order to create unique private mesh variable ids
-
-#     @timing.routine_timer_decorator
-#     def __init__(
-#         self,
-#         mesh: uw.discretisation.Mesh,
-#         psi_fn: sympy.Function,
-#         V_fn: sympy.Function,
-#         vtype: uw.VarType,
-#         degree: int,
-#         continuous: bool,
-#         varsymbol: Optional[str] = r"u",
-#         verbose: Optional[bool] = False,
-#         bcs=[],
-#         order=1,
-#         smoothing=0.0,
-#         fill_param=3,
-#     ):
-#         super().__init__()
-
-#         # create a new swarm to manage here
-#         dudt_swarm = uw.swarm.Swarm(mesh)
-
-#         self.mesh = mesh
-#         self.swarm = dudt_swarm
-#         self.psi_fn = psi_fn
-#         self.V_fn = V_fn
-#         self.verbose = verbose
-#         self.order = order
-
-#         psi_star = []
-#         self.psi_star = psi_star
-
-#         for i in range(order):
-#             print(f"Creating psi_star[{i}]")
-#             self.psi_star.append(
-#                 uw.swarm.SwarmVariable(
-#                     f"psi_star_sw_{self.instance_number}_{i}",
-#                     self.swarm,
-#                     vtype=vtype,
-#                     proxy_degree=degree,
-#                     proxy_continuous=continuous,
-#                     varsymbol=rf"{varsymbol}^{{ {'*'*(i+1)} }}",
-#                 )
-#             )
-
-#         dudt_swarm.populate(fill_param)
-
-#         return
-
-#     def _object_viewer(self):
-#         from IPython.display import Latex, Markdown, display
-
-#         super()._object_viewer()
-
-#         ## feedback on this instance
-#         display(Latex(r"$\quad\psi = $ " + self.psi._repr_latex_()))
-#         display(
-#             Latex(
-#                 r"$\quad\Delta t_{\textrm{phys}} = $ "
-#                 + sympy.sympify(self.dt_physical)._repr_latex_()
-#             )
-#         )
-#         display(Latex(rf"$\quad$History steps = {self.order}"))
-
-#     ## Note: We may be able to eliminate this
-#     ## The SL updater and the Lag updater have
-#     ## different sequencing because of the way they
-#     ## update the history. It makes more sense for the
-#     ## full Lagrangian swarm to be updated after the solve
-#     ## and this means we have to grab the history values first.
-
-#     def update(
-#         self,
-#         dt: float,
-#         evalf: Optional[bool] = False,
-#         verbose: Optional[bool] = False,
-#     ):
-#         self.update_post_solve(dt, evalf, verbose)
-#         return
-
-#     def update_pre_solve(
-#         self,
-#         dt: float,
-#         evalf: Optional[bool] = False,
-#         verbose: Optional[bool] = False,
-#     ):
-#         return
-
-#     def update_post_solve(
-#         self,
-#         dt: float,
-#         evalf: Optional[bool] = False,
-#         verbose: Optional[bool] = False,
-#     ):
-#         for h in range(self.order - 1):
-#             i = self.order - (h + 1)
-
-#             # copy the information down the chain
-#             print(f"Lagrange order = {self.order}")
-#             print(f"Lagrange copying {i-1} to {i}")
-
-#             with self.swarm.access(self.psi_star[i]):
-#                 self.psi_star[i].data[...] = self.psi_star[i - 1].data[...]
-
-#         # Now update the swarm variable
-
-#         if evalf:
-#             psi_star_0 = self.psi_star[0]
-#             with self.swarm.access(psi_star_0):
-#                 for i in range(psi_star_0.shape[0]):
-#                     for j in range(psi_star_0.shape[1]):
-#                         updated_psi = uw.function.evalf(
-#                             self.psi_fn[i, j], self.swarm.data
-#                         )
-#                         psi_star_0[i, j].data[:] = updated_psi
-
-#         else:
-#             psi_star_0 = self.psi_star[0]
-#             with self.swarm.access(psi_star_0):
-#                 for i in range(psi_star_0.shape[0]):
-#                     for j in range(psi_star_0.shape[1]):
-#                         updated_psi = uw.function.evaluate(
-#                             self.psi_fn[i, j], self.swarm.data
-#                         )
-#                         psi_star_0[i, j].data[:] = updated_psi
-
-#         # Now update the swarm locations
-
-#         self.swarm.advection(
-#             self.V_fn,
-#             delta_t=dt,
-#             restore_points_to_domain_func=self.mesh.return_coords_to_bounds,
-#         )
-
-#     def bdf(self, order=None):
-#         r"""Backwards differentiation form for calculating DuDt
-#         Note that you will need `bdf` / $\delta t$ in computing derivatives"""
-
-#         if order is None:
-#             order = self.order
-#         else:
-#             order = max(1, min(self.order, order))
-
-#         with sympy.core.evaluate(False):
-#             if order <= 1:
-#                 bdf0 = self.psi_fn - self.psi_star[0].sym
-
-#             elif order == 2:
-#                 bdf0 = (
-#                     3 * self.psi_fn / 2
-#                     - 2 * self.psi_star[0].sym
-#                     + self.psi_star[1].sym / 2
-#                 )
-
-#             elif order == 3:
-#                 bdf0 = (
-#                     11 * self.psi_fn / 6
-#                     - 3 * self.psi_star[0].sym
-#                     + 3 * self.psi_star[1].sym / 2
-#                     - self.psi_star[2].sym / 3
-#                 )
-
-#         return bdf0
-
-#     def adams_moulton_flux(self, order=None):
-#         if order is None:
-#             order = self.order
-#         else:
-#             order = max(1, min(self.order, order))
-
-#         with sympy.core.evaluate(False):
-#             if order == 1:
-#                 am = (self.psi_fn + self.psi_star[0].sym) / 2
-
-#             elif order == 2:
-#                 am = (
-#                     5 * self.psi_fn + 8 * self.psi_star[0].sym - self.psi_star[1].sym
-#                 ) / 12
-
-#             elif order == 3:
-#                 am = (
-#                     9 * self.psi_fn
-#                     + 19 * self.psi_star[0].sym
-#                     - 5 * self.psi_star[1].sym
-#                     + self.psi_star[2].sym
-#                 ) / 24
-
-#         return am
-
-
-# class Lagrangian_Swarm_D_Dt(uw_object):
-#     r"""Swarm-based Lagrangian History Manager:
-#     This manages the update of a Lagrangian variable, $\psi$ on the swarm across timesteps.
-
-#     $\quad \psi_p^{t-n\Delta t} \leftarrow \psi_p^{t-(n-1)\Delta t}\quad$
-
-#     $\quad \psi_p^{t-(n-1)\Delta t} \leftarrow \psi_p^{t-(n-2)\Delta t} \cdots\quad$
-
-#     $\quad \psi_p^{t-\Delta t} \leftarrow \psi_p^{t}$
-#     """
-
-#     instances = 0  # count how many of these there are in order to create unique private mesh variable ids
-
-#     @timing.routine_timer_decorator
-#     def __init__(
-#         self,
-#         swarm: Swarm,
-#         psi_fn: sympy.Function,
-#         vtype: uw.VarType,
-#         degree: int,
-#         continuous: bool,
-#         varsymbol: Optional[str] = r"u",
-#         verbose: Optional[bool] = False,
-#         bcs=[],
-#         order=1,
-#         smoothing=0.0,
-#     ):
-#         super().__init__()
-
-#         self.mesh = swarm.mesh
-#         self.swarm = swarm
-#         self.psi_fn = psi_fn
-#         self.verbose = verbose
-#         self.order = order
-
-#         psi_star = []
-#         self.psi_star = psi_star
-
-#         for i in range(order):
-#             print(f"Creating psi_star[{i}]")
-#             self.psi_star.append(
-#                 uw.swarm.SwarmVariable(
-#                     f"psi_star_sw_{self.instance_number}_{i}",
-#                     self.swarm,
-#                     vtype=vtype,
-#                     proxy_degree=degree,
-#                     proxy_continuous=continuous,
-#                     varsymbol=rf"{varsymbol}^{{ {'*'*(i+1)} }}",
-#                 )
-#             )
-
-#         return
-
-#     def _object_viewer(self):
-#         from IPython.display import Latex, Markdown, display
-
-#         super()._object_viewer()
-
-#         ## feedback on this instance
-#         display(Latex(r"$\quad\psi = $ " + self.psi._repr_latex_()))
-#         display(
-#             Latex(
-#                 r"$\quad\Delta t_{\textrm{phys}} = $ "
-#                 + sympy.sympify(self.dt_physical)._repr_latex_()
-#             )
-#         )
-#         display(Latex(rf"$\quad$History steps = {self.order}"))
-
-#     ## Note: We may be able to eliminate this
-#     ## The SL updater and the Lag updater have
-#     ## different sequencing because of the way they
-#     ## update the history. It makes more sense for the
-#     ## full Lagrangian swarm to be updated after the solve
-#     ## and this means we have to grab the history values first.
-
-#     def update(
-#         self,
-#         dt: float,
-#         evalf: Optional[bool] = False,
-#         verbose: Optional[bool] = False,
-#     ):
-#         self.update_post_solve(dt, evalf, verbose)
-#         return
-
-#     def update_pre_solve(
-#         self,
-#         dt: float,
-#         evalf: Optional[bool] = False,
-#         verbose: Optional[bool] = False,
-#     ):
-#         return
-
-#     def update_post_solve(
-#         self,
-#         dt: float,
-#         evalf: Optional[bool] = False,
-#         verbose: Optional[bool] = False,
-#     ):
-#         for h in range(self.order - 1):
-#             i = self.order - (h + 1)
-
-#             # copy the information down the chain
-#             print(f"Lagrange order = {self.order}")
-#             print(f"Lagrange copying {i-1} to {i}")
-
-#             with self.swarm.access(self.psi_star[i]):
-#                 self.psi_star[i].data[...] = self.psi_star[i - 1].data[...]
-
-#         # Now update the swarm variable
-
-#         if evalf:
-#             psi_star_0 = self.psi_star[0]
-#             with self.swarm.access(psi_star_0):
-#                 for i in range(psi_star_0.shape[0]):
-#                     for j in range(psi_star_0.shape[1]):
-#                         updated_psi = uw.function.evalf(
-#                             self.psi_fn[i, j], self.swarm.data
-#                         )
-#                         psi_star_0[i, j].data[:] = updated_psi
-
-#         else:
-#             psi_star_0 = self.psi_star[0]
-#             with self.swarm.access(psi_star_0):
-#                 for i in range(psi_star_0.shape[0]):
-#                     for j in range(psi_star_0.shape[1]):
-#                         updated_psi = uw.function.evaluate(
-#                             self.psi_fn[i, j], self.swarm.data
-#                         )
-#                         psi_star_0[i, j].data[:] = updated_psi
-
-#     def bdf(self, order=None):
-#         r"""Backwards differentiation form for calculating DuDt
-#         Note that you will need `bdf` / $\delta t$ in computing derivatives"""
-
-#         if order is None:
-#             order = self.order
-#         else:
-#             order = max(1, min(self.order, order))
-
-#         with sympy.core.evaluate(False):
-#             if order <= 1:
-#                 bdf0 = self.psi_fn - self.psi_star[0].sym
-
-#             elif order == 2:
-#                 bdf0 = (
-#                     3 * self.psi_fn / 2
-#                     - 2 * self.psi_star[0].sym
-#                     + self.psi_star[1].sym / 2
-#                 )
-
-#             elif order == 3:
-#                 bdf0 = (
-#                     11 * self.psi_fn / 6
-#                     - 3 * self.psi_star[0].sym
-#                     + 3 * self.psi_star[1].sym / 2
-#                     - self.psi_star[2].sym / 3
-#                 )
-
-#         return bdf0
-
-#     def adams_moulton_flux(self, order=None):
-#         if order is None:
-#             order = self.order
-#         else:
-#             order = max(1, min(self.order, order))
-
-#         with sympy.core.evaluate(False):
-#             if order == 1:
-#                 am = (self.psi_fn + self.psi_star[0].sym) / 2
-
-#             elif order == 2:
-#                 am = (
-#                     5 * self.psi_fn + 8 * self.psi_star[0].sym - self.psi_star[1].sym
-#                 ) / 12
-
-#             elif order == 3:
-#                 am = (
-#                     9 * self.psi_fn
-#                     + 19 * self.psi_star[0].sym
-#                     - 5 * self.psi_star[1].sym
-#                     + self.psi_star[2].sym
-#                 ) / 24
-
-#         return am
+    @timing.routine_timer_decorator
+    def advection(
+        self,
+        V_fn,
+        delta_t,
+        order=2,
+        corrector=False,
+        restore_points_to_domain_func=None,
+        bc_mask_fn=None,
+        evalf=False,
+    ):
+        # X0 holds the particle location at the start of advection
+        # This is needed because the particles may be migrated off-proc
+        # during timestepping.
+
+        X0 = self._X0
+
+        # Use current velocity to estimate where the particles would have
+        # landed in an implicit step.
+
+        # ? how does this interact with the particle restoration function ?
+
+        V_fn_matrix = self.mesh.vector.to_matrix(V_fn)
+
+        bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data).reshape(-1))
+
+        # if corrector == True and not self._X0_uninitialised:
+        #     with self.access(self.particle_coordinates):
+        #         v_at_Vpts = np.zeros_like(self.data)
+
+        #         if evalf:
+        #             for d in range(self.dim):
+        #                 v_at_Vpts[:, d] = uw.function.evalf(
+        #                     V_fn_matrix[d], self.data
+        #                 ).reshape(-1)
+        #         else:
+        #             for d in range(self.dim):
+        #                 v_at_Vpts[:, d] = uw.function.evaluate(
+        #                     V_fn_matrix[d], self.data
+        #                 ).reshape(-1)
+
+        #         corrected_position = X0.data.copy() + delta_t * v_at_Vpts
+        #         if restore_points_to_domain_func is not None:
+        #             corrected_position = restore_points_to_domain_func(
+        #                 corrected_position
+        #             )
+
+        #         updated_current_coords = 0.5 * (corrected_position + self.data.copy())
+
+        #         # validate_coords to ensure they live within the domain (or there will be trouble)
+
+        #         if restore_points_to_domain_func is not None:
+        #             updated_current_coords = restore_points_to_domain_func(
+        #                 updated_current_coords
+        #             )
+
+        #         self.data[...] = updated_current_coords[...]
+
+        #         del updated_current_coords
+        #         del v_at_Vpts
+
+        with self.access(X0):
+            X0.data[...] = self.data[...]
+            self._X0_uninitialised = False
+
+        # Mid point algorithm (2nd order)
+        if order == 2:
+            with self.access(self.particle_coordinates):
+                v_at_Vpts = np.zeros_like(self.data)
+
+                if evalf:
+                    for d in range(self.dim):
+                        v_at_Vpts[:, d] = uw.function.evalf(
+                            V_fn_matrix[d], self.data
+                        ).reshape(-1)
+                else:
+                    for d in range(self.dim):
+                        v_at_Vpts[:, d] = uw.function.evaluate(
+                            V_fn_matrix[d], self.data
+                        ).reshape(-1)
+
+                mid_pt_coords = (
+                    self.data[...].copy() + 0.5 * delta_t * v_at_Vpts * bc_mask_fn
+                )
+
+                # validate_coords to ensure they live within the domain (or there will be trouble)
+
+                if restore_points_to_domain_func is not None:
+                    mid_pt_coords = restore_points_to_domain_func(mid_pt_coords)
+
+                self.data[...] = mid_pt_coords[...]
+
+                del mid_pt_coords
+
+                ## Let the swarm be updated, and then move the rest of the way
+
+            with self.access(self.particle_coordinates):
+                v_at_Vpts = np.zeros_like(self.data)
+
+                if evalf:
+                    for d in range(self.dim):
+                        v_at_Vpts[:, d] = uw.function.evalf(
+                            V_fn_matrix[d], self.data
+                        ).reshape(-1)
+                else:
+                    for d in range(self.dim):
+                        v_at_Vpts[:, d] = uw.function.evaluate(
+                            V_fn_matrix[d], self.data
+                        ).reshape(-1)
+
+                # if (uw.mpi.rank == 0):
+                #     print("Re-launch from X0", flush=True)
+
+                new_coords = X0.data[...].copy() + delta_t * v_at_Vpts * bc_mask_fn
+
+                # validate_coords to ensure they live within the domain (or there will be trouble)
+                if restore_points_to_domain_func is not None:
+                    new_coords = restore_points_to_domain_func(new_coords)
+
+                self.data[...] = new_coords[...]
+
+                del new_coords
+                del v_at_Vpts
+
+        # Previous position algorithm (cf above) - we use the previous step as the
+        # launch point using the current velocity field. This gives a correction to the previous
+        # landing point.
+
+        # assumes X0 is stored from the previous step ... midpoint is needed in the first step
+
+        # forward Euler (1st order)
+        else:
+            with self.access(self.particle_coordinates):
+                v_at_Vpts = np.zeros_like(self.data)
+
+                if evalf:
+                    for d in range(self.dim):
+                        v_at_Vpts[:, d] = uw.function.evalf(
+                            V_fn_matrix[d], self.data
+                        ).reshape(-1)
+                else:
+                    for d in range(self.dim):
+                        v_at_Vpts[:, d] = uw.function.evaluate(
+                            V_fn_matrix[d], self.data
+                        ).reshape(-1)
+
+                new_coords = self.data + delta_t * v_at_Vpts * bc_mask_fn
+
+                # validate_coords to ensure they live within the domain (or there will be trouble)
+
+                if restore_points_to_domain_func is not None:
+                    new_coords = restore_points_to_domain_func(new_coords)
+
+                self.data[...] = new_coords[...].copy()

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -1872,7 +1872,7 @@ class NodalPointSwarm(Swarm):
 
         # Move slightly within the chosen cell to avoid edge effects
         centroid_coords = self.mesh._centroids[cellid]
-        shift = 0.0
+        shift = 1.0e-3
         coords[...] = (1.0 - shift) * coords[...] + shift * centroid_coords[...]
 
         nswarm.dm.restoreField("DMSwarmPIC_coor")
@@ -1888,6 +1888,42 @@ class NodalPointSwarm(Swarm):
         return
 
     @timing.routine_timer_decorator
+    def estimate_dt(self, V_fn):
+        """
+        Calculates an appropriate advective timestep for the given
+        mesh and velocity configuration.
+        """
+        # we'll want to do this on an element by element basis
+        # for more general mesh
+
+        # first let's extract a max global velocity magnitude
+        import math
+
+        with self.access():
+            vel = uw.function.evalf(V_fn, self.particle_coordinates.data)
+            magvel_squared = vel[:, 0] ** 2 + vel[:, 1] ** 2
+            if self.mesh.dim == 3:
+                magvel_squared += vel[:, 2] ** 2
+
+            max_magvel = math.sqrt(magvel_squared.max())
+
+        from mpi4py import MPI
+
+        comm = MPI.COMM_WORLD
+        max_magvel_glob = comm.allreduce(max_magvel, op=MPI.MAX)
+
+        min_dx = self.mesh.get_min_radius()
+
+        # The assumption should be that we cross one or two elements (4 radii), not more,
+        # in a single step (order 2, means one element per half-step or something
+        # that we can broadly interpret that way)
+
+        if max_magvel_glob != 0.0:
+            return 4.0 * min_dx / max_magvel_glob
+        else:
+            return None
+
+    @timing.routine_timer_decorator
     def advection(
         self,
         V_fn,
@@ -1895,12 +1931,24 @@ class NodalPointSwarm(Swarm):
         order=2,
         corrector=False,
         restore_points_to_domain_func=None,
-        bc_mask_fn=sympy.sympify(1),
         evalf=False,
+        _bc_mask_fn=sympy.sympify(1),
     ):
         # X0 holds the particle location at the start of advection
         # This is needed because the particles may be migrated off-proc
         # during timestepping.
+
+        dt_limit = self.estimate_dt(V_fn)
+
+        if dt_limit is not None:
+            substeps = int(max(1, abs(delta_t) // dt_limit))
+        else:
+            substeps = 1
+
+        # print(
+        #     f"NSWARM - dt_max - {dt_limit}; dt_requested - {delta_t} -> {substeps}",
+        #     flush=True,
+        # )
 
         X0 = self._X0
 
@@ -1911,141 +1959,120 @@ class NodalPointSwarm(Swarm):
 
         V_fn_matrix = self.mesh.vector.to_matrix(V_fn)
 
-        # if corrector == True and not self._X0_uninitialised:
-        #     with self.access(self.particle_coordinates):
-        #         v_at_Vpts = np.zeros_like(self.data)
-
-        #         if evalf:
-        #             for d in range(self.dim):
-        #                 v_at_Vpts[:, d] = uw.function.evalf(
-        #                     V_fn_matrix[d], self.data
-        #                 ).reshape(-1)
-        #         else:
-        #             for d in range(self.dim):
-        #                 v_at_Vpts[:, d] = uw.function.evaluate(
-        #                     V_fn_matrix[d], self.data
-        #                 ).reshape(-1)
-
-        #         corrected_position = X0.data.copy() + delta_t * v_at_Vpts
-        #         if restore_points_to_domain_func is not None:
-        #             corrected_position = restore_points_to_domain_func(
-        #                 corrected_position
-        #             )
-
-        #         updated_current_coords = 0.5 * (corrected_position + self.data.copy())
-
-        #         # validate_coords to ensure they live within the domain (or there will be trouble)
-
-        #         if restore_points_to_domain_func is not None:
-        #             updated_current_coords = restore_points_to_domain_func(
-        #                 updated_current_coords
-        #             )
-
-        #         self.data[...] = updated_current_coords[...]
-
-        #         del updated_current_coords
-        #         del v_at_Vpts
-
         with self.access(X0):
             X0.data[...] = self.data[...]
             self._X0_uninitialised = False
 
-        # Mid point algorithm (2nd order)
-        if order == 2:
-            with self.access(self.particle_coordinates):
-                v_at_Vpts = np.zeros_like(self.data)
+        # Wrap this whole thing in sub-stepping loop
 
-                if evalf:
-                    for d in range(self.dim):
-                        v_at_Vpts[:, d] = uw.function.evalf(
-                            V_fn_matrix[d], self.data
-                        ).reshape(-1)
-                else:
-                    for d in range(self.dim):
-                        v_at_Vpts[:, d] = uw.function.evaluate(
-                            V_fn_matrix[d], self.data
-                        ).reshape(-1)
+        for step in range(0, substeps):
 
-                bc_mask_array = np.rint(
-                    uw.function.evalf(bc_mask_fn, self.data)
-                ).reshape(-1, 1)
+            # Mid point algorithm (2nd order)
+            if order == 2:
+                with self.access(self.particle_coordinates):
+                    v_at_Vpts = np.zeros_like(self.data)
 
-                mid_pt_coords = (
-                    self.data[...].copy() + 0.5 * delta_t * v_at_Vpts * bc_mask_array
-                )
+                    if evalf:
+                        for d in range(self.dim):
+                            v_at_Vpts[:, d] = uw.function.evalf(
+                                V_fn_matrix[d], self.data
+                            ).reshape(-1)
+                    else:
+                        for d in range(self.dim):
+                            v_at_Vpts[:, d] = uw.function.evaluate(
+                                V_fn_matrix[d], self.data
+                            ).reshape(-1)
 
-                # validate_coords to ensure they live within the domain (or there will be trouble)
+                    bc_mask_array = np.rint(
+                        uw.function.evalf(_bc_mask_fn, self.data)
+                    ).reshape(-1, 1)
 
-                if restore_points_to_domain_func is not None:
-                    mid_pt_coords = restore_points_to_domain_func(mid_pt_coords)
+                    mid_pt_coords = (
+                        self.data[...].copy()
+                        + 0.5 * delta_t * v_at_Vpts * bc_mask_array / substeps
+                    )
 
-                self.data[...] = mid_pt_coords[...]
+                    # validate_coords to ensure they live within the domain (or there will be trouble)
 
-                del mid_pt_coords
+                    if restore_points_to_domain_func is not None:
+                        mid_pt_coords = restore_points_to_domain_func(mid_pt_coords)
 
-                ## Let the swarm be updated, and then move the rest of the way
+                    self.data[...] = mid_pt_coords[...]
 
-            with self.access(self.particle_coordinates):
-                v_at_Vpts = np.zeros_like(self.data)
+                    del mid_pt_coords
 
-                if evalf:
-                    for d in range(self.dim):
-                        v_at_Vpts[:, d] = uw.function.evalf(
-                            V_fn_matrix[d], self.data
-                        ).reshape(-1)
-                else:
-                    for d in range(self.dim):
-                        v_at_Vpts[:, d] = uw.function.evaluate(
-                            V_fn_matrix[d], self.data
-                        ).reshape(-1)
+                    ## Let the swarm be updated, and then move the rest of the way
 
-                # if (uw.mpi.rank == 0):
-                #     print("Re-launch from X0", flush=True)
+                with self.access(self.particle_coordinates):
+                    v_at_Vpts = np.zeros_like(self.data)
 
-                bc_mask_array = np.rint(
-                    uw.function.evalf(bc_mask_fn, self.data)
-                ).reshape(-1, 1)
-                new_coords = X0.data[...].copy() + delta_t * v_at_Vpts * bc_mask_array
+                    if evalf:
+                        for d in range(self.dim):
+                            v_at_Vpts[:, d] = uw.function.evalf(
+                                V_fn_matrix[d], self.data
+                            ).reshape(-1)
+                    else:
+                        for d in range(self.dim):
+                            v_at_Vpts[:, d] = uw.function.evaluate(
+                                V_fn_matrix[d], self.data
+                            ).reshape(-1)
 
-                # validate_coords to ensure they live within the domain (or there will be trouble)
-                if restore_points_to_domain_func is not None:
-                    new_coords = restore_points_to_domain_func(new_coords)
+                    # if (uw.mpi.rank == 0):
+                    #     print("Re-launch from X0", flush=True)
 
-                self.data[...] = new_coords[...]
+                    bc_mask_array = np.rint(
+                        uw.function.evalf(_bc_mask_fn, self.data)
+                    ).reshape(-1, 1)
+                    new_coords = (
+                        X0.data[...].copy()
+                        + delta_t * v_at_Vpts * bc_mask_array / substeps
+                    )
 
-                del new_coords
-                del v_at_Vpts
+                    # validate_coords to ensure they live within the domain (or there will be trouble)
+                    if restore_points_to_domain_func is not None:
+                        new_coords = restore_points_to_domain_func(new_coords)
 
-        # Previous position algorithm (cf above) - we use the previous step as the
-        # launch point using the current velocity field. This gives a correction to the previous
-        # landing point.
+                    self.data[...] = new_coords[...]
 
-        # assumes X0 is stored from the previous step ... midpoint is needed in the first step
+                    del new_coords
+                    del v_at_Vpts
 
-        # forward Euler (1st order)
-        else:
-            with self.access(self.particle_coordinates):
-                v_at_Vpts = np.zeros_like(self.data)
+            # Previous position algorithm (cf above) - we use the previous step as the
+            # launch point using the current velocity field. This gives a correction to the previous
+            # landing point.
 
-                if evalf:
-                    for d in range(self.dim):
-                        v_at_Vpts[:, d] = uw.function.evalf(
-                            V_fn_matrix[d], self.data
-                        ).reshape(-1)
-                else:
-                    for d in range(self.dim):
-                        v_at_Vpts[:, d] = uw.function.evaluate(
-                            V_fn_matrix[d], self.data
-                        ).reshape(-1)
+            # assumes X0 is stored from the previous step ... midpoint is needed in the first step
 
-                bc_mask_array = np.rint(
-                    uw.function.evalf(bc_mask_fn, self.data)
-                ).reshape(-1, 1)
-                new_coords = self.data + delta_t * v_at_Vpts * bc_mask_array
+            # forward Euler (1st order)
+            else:
+                with self.access(self.particle_coordinates):
+                    v_at_Vpts = np.zeros_like(self.data)
 
-                # validate_coords to ensure they live within the domain (or there will be trouble)
+                    if evalf:
+                        for d in range(self.dim):
+                            v_at_Vpts[:, d] = uw.function.evalf(
+                                V_fn_matrix[d], self.data
+                            ).reshape(-1)
+                    else:
+                        for d in range(self.dim):
+                            v_at_Vpts[:, d] = uw.function.evaluate(
+                                V_fn_matrix[d], self.data
+                            ).reshape(-1)
 
-                if restore_points_to_domain_func is not None:
-                    new_coords = restore_points_to_domain_func(new_coords)
+                    bc_mask_array = np.rint(
+                        uw.function.evalf(_bc_mask_fn, self.data)
+                    ).reshape(-1, 1)
+                    new_coords = (
+                        self.data + delta_t * v_at_Vpts * bc_mask_array / substeps
+                    )
 
-                self.data[...] = new_coords[...].copy()
+                    # validate_coords to ensure they live within the domain (or there will be trouble)
+
+                    if restore_points_to_domain_func is not None:
+                        new_coords = restore_points_to_domain_func(new_coords)
+
+                    self.data[...] = new_coords[...].copy()
+
+            # print(f"Substep - {step}", flush=True)
+
+        # End substepping loop

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -1872,7 +1872,7 @@ class NodalPointSwarm(Swarm):
 
         # Move slightly within the chosen cell to avoid edge effects
         centroid_coords = self.mesh._centroids[cellid]
-        shift = 1.0e-2
+        shift = 1.0e-6
         coords[...] = (1.0 - shift) * coords[...] + shift * centroid_coords[...]
 
         nswarm.dm.restoreField("DMSwarmPIC_coor")

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -1912,7 +1912,9 @@ class NodalPointSwarm(Swarm):
         V_fn_matrix = self.mesh.vector.to_matrix(V_fn)
 
         with self.access():
-            bc_mask_fn = np.rint(uw.function.evalf(bc_mask_fn, self.data).reshape(-1))
+            bc_mask_fn = np.rint(
+                uw.function.evalf(bc_mask_fn, self.data).reshape(-1, 1)
+            )
 
         # if corrector == True and not self._X0_uninitialised:
         #     with self.access(self.particle_coordinates):

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -181,6 +181,9 @@ class SemiLagrangian(uw_object):
 
         # 2. Compute the upstream values
 
+        if verbose and uw.mpi.rank == 0:
+            print(f"Update {self.psi_fn}", flush=True)
+
         # We use the u_star variable as a working value here so we have to work backwards
         for i in range(self.order - 1, -1, -1):
             with self._nswarm_psi.access(self._nswarm_psi._X0):
@@ -200,11 +203,20 @@ class SemiLagrangian(uw_object):
                 self._psi_star_projection_solver.uw_function = self.psi_fn
                 self._psi_star_projection_solver.solve()
 
-            with self._nswarm_psi.access(self._nswarm_psi.swarmVariable):
-                for d in range(self.psi_star[i].shape[1]):
-                    self._nswarm_psi.swarmVariable.data[:, d] = uw.function.evaluate(
-                        self.psi_star[i].sym[d], self._nswarm_psi.data
-                    )
+            if evalf:
+                with self._nswarm_psi.access(self._nswarm_psi.swarmVariable):
+                    for d in range(self.psi_star[i].shape[1]):
+                        self._nswarm_psi.swarmVariable.data[:, d] = uw.function.evalf(
+                            self.psi_star[i].sym[d], self._nswarm_psi.data
+                        )
+            else:
+                with self._nswarm_psi.access(self._nswarm_psi.swarmVariable):
+                    for d in range(self.psi_star[i].shape[1]):
+                        self._nswarm_psi.swarmVariable.data[:, d] = (
+                            uw.function.evaluate(
+                                self.psi_star[i].sym[d], self._nswarm_psi.data
+                            )
+                        )
 
             # restore coords (will call dm.migrate after context manager releases)
             with self._nswarm_psi.access(self._nswarm_psi.particle_coordinates):

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -199,7 +199,6 @@ class SemiLagrangian(uw_object):
                 order=2,
                 corrector=False,
                 restore_points_to_domain_func=self.mesh.return_coords_to_bounds,
-                bc_mask_fn=self.bc_mask_fn,
                 evalf=evalf,
             )
 

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -172,7 +172,7 @@ class SemiLagrangian(uw_object):
         # 1. Copy the stored values down the chain
 
         if dt_physical is not None:
-            phi = min(1.0, dt / dt_physical)
+            phi = min(1, dt / dt_physical)
         else:
             phi = sympy.sympify(1)
 

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -163,14 +163,23 @@ class SemiLagrangian(uw_object):
         dt: float,
         evalf: Optional[bool] = False,
         verbose: Optional[bool] = False,
+        dt_physical: Optional[float] = None,
     ):
 
         ## Progress from the oldest part of the history
         # 1. Copy the stored values down the chain
 
+        if dt_physical is not None:
+            phi = min(1.0, dt / dt_physical)
+        else:
+            phi = sympy.sympify(1)
+
         for i in range(self.order - 1, 0, -1):
             with self.mesh.access(self.psi_star[i]):
-                self.psi_star[i].data[...] = self.psi_star[i - 1].data[...]
+                self.psi_star[i].data[...] = (
+                    phi * self.psi_star[i - 1].data[...]
+                    + (1 - phi) * self.psi_star[i].data[...]
+                )
 
         # 2. Compute the upstream values
 
@@ -284,7 +293,7 @@ class SemiLagrangian(uw_object):
 
 
 ## Consider Deprecating this one - it is the same as the Lagrangian_Swarm but
-## sets up the swarm for itself. This does not have much use - the swarm version
+## sets up the swarm for itself. This does not have a practical use-case - the swarm version
 ## is slower, more cumbersome, and less stable / accurate. The only reason to use
 ## it is if there is an existing swarm that we can re-purpose.
 

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -146,8 +146,9 @@ class SemiLagrangian(uw_object):
         dt: float,
         evalf: Optional[bool] = False,
         verbose: Optional[bool] = False,
+        dt_physical: Optional = None,
     ):
-        self.update_pre_solve(dt, evalf, verbose)
+        self.update_pre_solve(dt, evalf, verbose, dt_physical)
         return
 
     def update_post_solve(
@@ -155,6 +156,7 @@ class SemiLagrangian(uw_object):
         dt: float,
         evalf: Optional[bool] = False,
         verbose: Optional[bool] = False,
+        dt_physical: Optional[float] = None,
     ):
         return
 

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -41,6 +41,7 @@ class SemiLagrangian(uw_object):
         order=1,
         smoothing=0.0,
         under_relaxation=0.0,
+        bc_mask_fn=1,
     ):
         super().__init__()
 
@@ -60,7 +61,7 @@ class SemiLagrangian(uw_object):
         # meshVariable (storage)
 
         self._psi_fn = psi_fn
-        self.V_fn = V_fn
+        self.V_fn = bc_mask_fn * V_fn
         self.order = order
 
         psi_star = []

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -196,6 +196,7 @@ class SemiLagrangian(uw_object):
                 order=2,
                 corrector=False,
                 restore_points_to_domain_func=self.mesh.return_coords_to_bounds,
+                evalf=evalf,
             )
 
             if i == 0:

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -442,11 +442,12 @@ class Lagrangian(uw_object):
 
         if order is None:
             order = self.order
-        else:
-            order = max(1, min(self.order, order))
 
         with sympy.core.evaluate(False):
-            if order <= 1:
+            if order == 0:  # special case - no history term (catch )
+                bdf0 = sympy.simpify[0]
+
+            if order == 1:
                 bdf0 = self.psi_fn - self.psi_star[0].sym
 
             elif order == 2:
@@ -469,11 +470,12 @@ class Lagrangian(uw_object):
     def adams_moulton_flux(self, order=None):
         if order is None:
             order = self.order
-        else:
-            order = max(1, min(self.order, order))
 
         with sympy.core.evaluate(False):
-            if order == 1:
+            if order == 0:  # Special case - no history term
+                am = self.psi_fn
+
+            elif order == 1:
                 am = (self.psi_fn + self.psi_star[0].sym) / 2
 
             elif order == 2:

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -61,8 +61,9 @@ class SemiLagrangian(uw_object):
         # meshVariable (storage)
 
         self._psi_fn = psi_fn
-        self.V_fn = bc_mask_fn * V_fn
+        self.V_fn = V_fn
         self.order = order
+        self.bc_mask_fn = bc_mask_fn
 
         psi_star = []
         self.psi_star = psi_star
@@ -198,7 +199,9 @@ class SemiLagrangian(uw_object):
                 order=2,
                 corrector=False,
                 restore_points_to_domain_func=self.mesh.return_coords_to_bounds,
+                bc_mask_fn=self.bc_mask_fn
                 evalf=evalf,
+
             )
 
             if i == 0:

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -182,7 +182,7 @@ class SemiLagrangian(uw_object):
         # 2. Compute the upstream values
 
         if verbose and uw.mpi.rank == 0:
-            print(f"Update {self.psi_fn}", flush=True)
+            print(f"Update 2 {self.psi_fn}", flush=True)
 
         # We use the u_star variable as a working value here so we have to work backwards
         for i in range(self.order - 1, -1, -1):
@@ -218,6 +218,9 @@ class SemiLagrangian(uw_object):
                             )
                         )
 
+            if verbose and uw.mpi.rank == 0:
+                print(f"Update 3 {self.psi_fn}", flush=True)
+
             # restore coords (will call dm.migrate after context manager releases)
             with self._nswarm_psi.access(self._nswarm_psi.particle_coordinates):
                 self._nswarm_psi.data[...] = self._nswarm_psi._X0.data[...]
@@ -226,7 +229,14 @@ class SemiLagrangian(uw_object):
             self._psi_star_projection_solver.uw_function = (
                 self._nswarm_psi.swarmVariable.sym
             )
+
+            if verbose and uw.mpi.rank == 0:
+                print(f"Update 4 {self.psi_fn}", flush=True)
+
             self._psi_star_projection_solver.solve()
+
+            if verbose and uw.mpi.rank == 0:
+                print(f"Update 5 {self.psi_fn}", flush=True)
 
             # Copy data from the projection operator if required
             if i != 0:

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -199,9 +199,8 @@ class SemiLagrangian(uw_object):
                 order=2,
                 corrector=False,
                 restore_points_to_domain_func=self.mesh.return_coords_to_bounds,
-                bc_mask_fn=self.bc_mask_fn
+                bc_mask_fn=self.bc_mask_fn,
                 evalf=evalf,
-
             )
 
             if i == 0:

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -164,13 +164,6 @@ class SemiLagrangian(uw_object):
         evalf: Optional[bool] = False,
         verbose: Optional[bool] = False,
     ):
-        # if average_over_dt:
-        #     phi = min(1.0, dt / self.dt_physical)
-        # else:
-        #     phi = 1.0
-
-        if verbose and uw.mpi.rank == 0:
-            print(f"Update {self.psi_fn}", flush=True)
 
         ## Progress from the oldest part of the history
         # 1. Copy the stored values down the chain
@@ -180,9 +173,6 @@ class SemiLagrangian(uw_object):
                 self.psi_star[i].data[...] = self.psi_star[i - 1].data[...]
 
         # 2. Compute the upstream values
-
-        if verbose and uw.mpi.rank == 0:
-            print(f"Update 2 {self.psi_fn}", flush=True)
 
         # We use the u_star variable as a working value here so we have to work backwards
         for i in range(self.order - 1, -1, -1):
@@ -219,9 +209,6 @@ class SemiLagrangian(uw_object):
                             )
                         )
 
-            if verbose and uw.mpi.rank == 0:
-                print(f"Update 3 {self.psi_fn}", flush=True)
-
             # restore coords (will call dm.migrate after context manager releases)
             with self._nswarm_psi.access(self._nswarm_psi.particle_coordinates):
                 self._nswarm_psi.data[...] = self._nswarm_psi._X0.data[...]
@@ -231,13 +218,7 @@ class SemiLagrangian(uw_object):
                 self._nswarm_psi.swarmVariable.sym
             )
 
-            if verbose and uw.mpi.rank == 0:
-                print(f"Update 4 {self.psi_fn}", flush=True)
-
             self._psi_star_projection_solver.solve()
-
-            if verbose and uw.mpi.rank == 0:
-                print(f"Update 5 {self.psi_fn}", flush=True)
 
             # Copy data from the projection operator if required
             if i != 0:

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2589,8 +2589,8 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             print(f"NS solver - pre-solve DuDt update", flush=True)
 
         # Update SemiLagrange Flux terms
-        self.DuDt.update_pre_solve(timestep, verbose=verbose, evalf=evalf, order=order)
-        self.DFDt.update_pre_solve(timestep, verbose=verbose, evalf=evalf, order=order)
+        self.DuDt.update_pre_solve(timestep, verbose=verbose, evalf=evalf)
+        self.DFDt.update_pre_solve(timestep, verbose=verbose, evalf=evalf)
 
         if uw.mpi.rank == 0 and verbose:
             print(f"NS solver - solve Stokes flow", flush=True)
@@ -2605,8 +2605,8 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
         if uw.mpi.rank == 0 and verbose:
             print(f"NS solver - post-solve DuDt update", flush=True)
 
-        self.DuDt.update_post_solve(timestep, verbose=verbose, evalf=evalf, order=order)
-        self.DFDt.update_post_solve(timestep, verbose=verbose, evalf=evalf, order=order)
+        self.DuDt.update_post_solve(timestep, verbose=verbose, evalf=evalf)
+        self.DFDt.update_post_solve(timestep, verbose=verbose, evalf=evalf)
 
         self.is_setup = True
         self.constitutive_model._solver_is_setup = True

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2346,7 +2346,6 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
 
         # These are unique to the advection solver
         self.delta_t = sympy.oo
-        self.delta_t_physical = None
 
         self.is_setup = False
         self.rho = rho
@@ -2409,7 +2408,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
                 bcs=None,
                 order=self._order,
                 smoothing=0.0,
-                bc_mask_fn=bc_mask_fn,
+                bc_mask_fn=None,
             )
 
         ## Add in the history terms provided ...
@@ -2419,16 +2418,9 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
     def navier_stokes_problem_description(self):
         # f0 residual term
 
-        if self.delta_t_physical is not None:
-            self._u_f0 = (
-                self.F0
-                - self.bodyforce
-                + self.rho * self.DuDt.bdf() / self.delta_t_physical
-            )
-        else:
-            self._u_f0 = (
-                self.F0 - self.bodyforce + self.rho * self.DuDt.bdf() / self.delta_t
-            )
+        self._u_f0 = (
+            self.F0 - self.bodyforce + self.rho * self.DuDt.bdf() / self.delta_t
+        )
 
         # f1 residual term
         self._u_f1 = (
@@ -2448,15 +2440,6 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
     def delta_t(self, value):
         self.is_setup = False
         self._delta_t = sympify(value)
-
-    @property
-    def delta_t_physical(self):
-        return self._delta_t_physical
-
-    @delta_t_physical.setter
-    def delta_t_physical(self, value):
-        self.is_setup = False
-        self._delta_t_physical = sympify(value)
 
     @property
     def f(self):
@@ -2500,30 +2483,6 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
     ):
         self.Unknowns.DFDt = DFDt_value
         self._solver_is_setup = False
-
-    # @property
-    # def constitutive_model(self):
-    #     return self._constitutive_model
-
-    # @constitutive_model.setter
-    # def constitutive_model(self, model):
-    #     ### checking if it's an instance
-    #     if isinstance(model, uw.constitutive_models.Constitutive_Model):
-    #         self._constitutive_model = model
-    #         ### update history terms using setters
-    #         self._constitutive_model.flux_dt = self.DFDt
-    #         self._constitutive_model.DuDt = self.DuDt
-    #     ### checking if it's a class
-    #     elif type(model) == type(uw.constitutive_models.Constitutive_Model):
-    #         self._constitutive_model = model(self.u)
-    #         ### update history terms using setters
-    #         self._constitutive_model.flux_dt = self.DFDt
-    #         self._constitutive_model.DuDt = self.DuDt
-    #     ### Raise an error if it's neither
-    #     else:
-    #         raise RuntimeError(
-    #             "constitutive_model must be a valid class or instance of a valid class"
-    #         )
 
     @property
     def constraints(self):
@@ -2569,7 +2528,6 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
         self,
         zero_init_guess: bool = True,
         timestep: float = None,
-        physical_timestep: float = None,
         _force_setup: bool = False,
         verbose=False,
         evalf=False,
@@ -2607,12 +2565,8 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             print(f"NS solver - pre-solve DuDt update", flush=True)
 
         # Update SemiLagrange Flux terms
-        self.DuDt.update_pre_solve(
-            timestep, verbose=verbose, evalf=evalf, dt_physical=physical_timestep
-        )
-        self.DFDt.update_pre_solve(
-            timestep, verbose=verbose, evalf=evalf, dt_physical=physical_timestep
-        )
+        self.DuDt.update_pre_solve(timestep, verbose=verbose, evalf=evalf)
+        self.DFDt.update_pre_solve(timestep, verbose=verbose, evalf=evalf)
 
         if uw.mpi.rank == 0 and verbose:
             print(f"NS solver - solve Stokes flow", flush=True)
@@ -2627,12 +2581,8 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
         if uw.mpi.rank == 0 and verbose:
             print(f"NS solver - post-solve DuDt update", flush=True)
 
-        self.DuDt.update_post_solve(
-            timestep, verbose=verbose, evalf=evalf, dt_physical=physical_timestep
-        )
-        self.DFDt.update_post_solve(
-            timestep, verbose=verbose, evalf=evalf, dt_physical=physical_timestep
-        )
+        self.DuDt.update_post_solve(timestep, verbose=verbose, evalf=evalf)
+        self.DFDt.update_post_solve(timestep, verbose=verbose, evalf=evalf)
 
         self.is_setup = True
         self.constitutive_model._solver_is_setup = True

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2555,6 +2555,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
         _force_setup: bool = False,
         verbose=False,
         evalf=False,
+        order=None,
     ):
         """
         Generates solution to constructed system.
@@ -2565,6 +2566,9 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             If `True`, a zero initial guess will be used for the
             system solution. Otherwise, the current values of `self.u` will be used.
         """
+
+        if order is None or order > self.order:
+            order = self.order
 
         if timestep is not None and timestep != self.delta_t:
             self.delta_t = timestep  # this will force an initialisation because the functions need to be updated
@@ -2585,8 +2589,8 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             print(f"NS solver - pre-solve DuDt update", flush=True)
 
         # Update SemiLagrange Flux terms
-        self.DuDt.update_pre_solve(timestep, verbose=verbose, evalf=evalf)
-        self.DFDt.update_pre_solve(timestep, verbose=verbose, evalf=evalf)
+        self.DuDt.update_pre_solve(timestep, verbose=verbose, evalf=evalf, order=order)
+        self.DFDt.update_pre_solve(timestep, verbose=verbose, evalf=evalf, order=order)
 
         if uw.mpi.rank == 0 and verbose:
             print(f"NS solver - solve Stokes flow", flush=True)
@@ -2601,8 +2605,8 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
         if uw.mpi.rank == 0 and verbose:
             print(f"NS solver - post-solve DuDt update", flush=True)
 
-        self.DuDt.update_post_solve(timestep, verbose=verbose, evalf=evalf)
-        self.DFDt.update_post_solve(timestep, verbose=verbose, evalf=evalf)
+        self.DuDt.update_post_solve(timestep, verbose=verbose, evalf=evalf, order=order)
+        self.DFDt.update_post_solve(timestep, verbose=verbose, evalf=evalf, order=order)
 
         self.is_setup = True
         self.constitutive_model._solver_is_setup = True

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2329,7 +2329,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
         p_continuous: Optional[bool] = False,
         solver_name: Optional[str] = "",
         verbose: Optional[bool] = False,
-        bc_mask_fn: Optional[sympy.Function] = sympy.sympify(1),
+        bc_mask_fn: Optional[sympy.Function] = 1,
     ):
         ## Parent class will set up default values and load u_Field into the solver
         super().__init__(
@@ -2380,7 +2380,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             self.Unknowns.DuDt = uw.systems.ddt.SemiLagrangian(
                 self.mesh,
                 self.u.sym,
-                bc_mask_fn * self.u.sym,
+                1 * self.u.sym,
                 vtype=uw.VarType.VECTOR,
                 degree=self.u.degree,
                 continuous=self.u.continuous,

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2567,8 +2567,8 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             system solution. Otherwise, the current values of `self.u` will be used.
         """
 
-        if order is None or order > self.order:
-            order = self.order
+        if order is None or order > self._order:
+            order = self._order
 
         if timestep is not None and timestep != self.delta_t:
             self.delta_t = timestep  # this will force an initialisation because the functions need to be updated

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2380,7 +2380,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             self.Unknowns.DuDt = uw.systems.ddt.SemiLagrangian(
                 self.mesh,
                 self.u.sym,
-                1 * self.u.sym,
+                self.u.sym,
                 vtype=uw.VarType.VECTOR,
                 degree=self.u.degree,
                 continuous=self.u.continuous,
@@ -2389,6 +2389,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
                 bcs=self.essential_bcs,
                 order=self._order,
                 smoothing=0.0,
+                bc_mask_fn=bc_mask_fn,
             )
 
         # F (at least for N-S) is a nodal point variable so there is no benefit
@@ -2399,7 +2400,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             self.Unknowns.DFDt = uw.systems.ddt.SemiLagrangian(
                 self.mesh,
                 sympy.Matrix.zeros(self.mesh.dim, self.mesh.dim),
-                bc_mask_fn * self.u.sym,
+                self.u.sym,
                 vtype=uw.VarType.SYM_TENSOR,
                 degree=self.u.degree - 1,
                 continuous=True,
@@ -2408,6 +2409,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
                 bcs=None,
                 order=self._order,
                 smoothing=0.0,
+                bc_mask_fn=bc_mask_fn,
             )
 
         ## Add in the history terms provided ...

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2044,7 +2044,6 @@ class SNES_NavierStokes_SLCN(SNES_Stokes_SaddlePt):
         self._first_solve = True
 
         self._order = order
-
         self._constitutive_model = None
 
         self._penalty = 0.0
@@ -2060,7 +2059,7 @@ class SNES_NavierStokes_SLCN(SNES_Stokes_SaddlePt):
         self.Unknowns.DuDt = uw.systems.ddt.SemiLagrangian(
             self.mesh,
             self.u.sym,
-            self.u.sym,
+            self.u.sym * bc_mask,
             vtype=uw.VarType.VECTOR,
             degree=self.u.degree,
             continuous=self.u.continuous,
@@ -2330,6 +2329,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
         p_continuous: Optional[bool] = False,
         solver_name: Optional[str] = "",
         verbose: Optional[bool] = False,
+        bc_mask: Optional[sympy.Function] = sympy.sympify(1),
     ):
         ## Parent class will set up default values and load u_Field into the solver
         super().__init__(

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2552,6 +2552,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
         self,
         zero_init_guess: bool = True,
         timestep: float = None,
+        physical_timestep: float = None,
         _force_setup: bool = False,
         verbose=False,
         evalf=False,
@@ -2589,8 +2590,12 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             print(f"NS solver - pre-solve DuDt update", flush=True)
 
         # Update SemiLagrange Flux terms
-        self.DuDt.update_pre_solve(timestep, verbose=verbose, evalf=evalf)
-        self.DFDt.update_pre_solve(timestep, verbose=verbose, evalf=evalf)
+        self.DuDt.update_pre_solve(
+            timestep, verbose=verbose, evalf=evalf, dt_physical=physical_timestep
+        )
+        self.DFDt.update_pre_solve(
+            timestep, verbose=verbose, evalf=evalf, dt_physical=physical_timestep
+        )
 
         if uw.mpi.rank == 0 and verbose:
             print(f"NS solver - solve Stokes flow", flush=True)
@@ -2605,8 +2610,12 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
         if uw.mpi.rank == 0 and verbose:
             print(f"NS solver - post-solve DuDt update", flush=True)
 
-        self.DuDt.update_post_solve(timestep, verbose=verbose, evalf=evalf)
-        self.DFDt.update_post_solve(timestep, verbose=verbose, evalf=evalf)
+        self.DuDt.update_post_solve(
+            timestep, verbose=verbose, evalf=evalf, dt_physical=physical_timestep
+        )
+        self.DFDt.update_post_solve(
+            timestep, verbose=verbose, evalf=evalf, dt_physical=physical_timestep
+        )
 
         self.is_setup = True
         self.constitutive_model._solver_is_setup = True

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -375,6 +375,7 @@ class SNES_Stokes(SNES_Stokes_SaddlePt):
       - It is possible to set discontinuous pressure variables by setting the `p_continous` option to `False`
 
     """
+
     instances = 0
 
     def __init__(
@@ -638,6 +639,7 @@ class SNES_VE_Stokes(SNES_Stokes):
       - It is possible to set discontinuous pressure variables by setting the `p_continous` option to `False`
 
     """
+
     instances = 0
 
     def __init__(
@@ -2579,9 +2581,15 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             self._setup_discretisation(verbose)
             self._setup_solver(verbose)
 
+        if uw.mpi.rank == 0 and verbose:
+            print(f"NS solver - pre-solve DuDt update", flush=True)
+
         # Update SemiLagrange Flux terms
         self.DuDt.update_pre_solve(timestep, verbose=verbose, evalf=evalf)
         self.DFDt.update_pre_solve(timestep, verbose=verbose, evalf=evalf)
+
+        if uw.mpi.rank == 0 and verbose:
+            print(f"NS solver - solve Stokes flow", flush=True)
 
         super().solve(
             zero_init_guess,
@@ -2589,6 +2597,10 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             verbose=verbose,
             picard=0,
         )
+
+        if uw.mpi.rank == 0 and verbose:
+            print(f"NS solver - post-solve DuDt update", flush=True)
+
         self.DuDt.update_post_solve(timestep, verbose=verbose, evalf=evalf)
         self.DFDt.update_post_solve(timestep, verbose=verbose, evalf=evalf)
 

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2380,7 +2380,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             self.Unknowns.DuDt = uw.systems.ddt.SemiLagrangian(
                 self.mesh,
                 self.u.sym,
-                self.u.sym,
+                self.u.sym * bc_mask,
                 vtype=uw.VarType.VECTOR,
                 degree=self.u.degree,
                 continuous=self.u.continuous,
@@ -2399,7 +2399,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             self.Unknowns.DFDt = uw.systems.ddt.SemiLagrangian(
                 self.mesh,
                 sympy.Matrix.zeros(self.mesh.dim, self.mesh.dim),
-                self.u.sym,
+                self.u.sym * bc_mask,
                 vtype=uw.VarType.SYM_TENSOR,
                 degree=self.u.degree - 1,
                 continuous=True,

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2329,7 +2329,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
         p_continuous: Optional[bool] = False,
         solver_name: Optional[str] = "",
         verbose: Optional[bool] = False,
-        bc_mask: Optional[sympy.Function] = sympy.sympify(1),
+        bc_mask_fn: Optional[sympy.Function] = sympy.sympify(1),
     ):
         ## Parent class will set up default values and load u_Field into the solver
         super().__init__(
@@ -2380,7 +2380,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             self.Unknowns.DuDt = uw.systems.ddt.SemiLagrangian(
                 self.mesh,
                 self.u.sym,
-                bc_mask.sym[0] * self.u.sym,
+                bc_mask_fn * self.u.sym,
                 vtype=uw.VarType.VECTOR,
                 degree=self.u.degree,
                 continuous=self.u.continuous,
@@ -2399,7 +2399,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             self.Unknowns.DFDt = uw.systems.ddt.SemiLagrangian(
                 self.mesh,
                 sympy.Matrix.zeros(self.mesh.dim, self.mesh.dim),
-                bc_mask.sym[0] * self.u.sym,
+                bc_mask_fn * self.u.sym,
                 vtype=uw.VarType.SYM_TENSOR,
                 degree=self.u.degree - 1,
                 continuous=True,

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2346,6 +2346,8 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
 
         # These are unique to the advection solver
         self.delta_t = sympy.oo
+        self.delta_t_physical = None
+
         self.is_setup = False
         self.rho = rho
         self._first_solve = True
@@ -2357,10 +2359,6 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
         self._penalty = 0.0
 
         self._constitutive_model = None
-
-        # These are unique to the advection solver
-        self.delta_t = 0.0
-        self.is_setup = False
 
         self.restore_points_to_domain_func = restore_points_func
         self._setup_problem_description = self.navier_stokes_problem_description
@@ -2418,9 +2416,17 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
 
     def navier_stokes_problem_description(self):
         # f0 residual term
-        self._u_f0 = (
-            self.F0 - self.bodyforce + self.rho * self.DuDt.bdf() / self.delta_t
-        )
+
+        if self.delta_t_physical is not None:
+            self._u_f0 = (
+                self.F0
+                - self.bodyforce
+                + self.rho * self.DuDt.bdf() / self.delta_t_physical
+            )
+        else:
+            self._u_f0 = (
+                self.F0 - self.bodyforce + self.rho * self.DuDt.bdf() / self.delta_t
+            )
 
         # f1 residual term
         self._u_f1 = (
@@ -2440,6 +2446,15 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
     def delta_t(self, value):
         self.is_setup = False
         self._delta_t = sympify(value)
+
+    @property
+    def delta_t_physical(self):
+        return self._delta_t_physical
+
+    @delta_t_physical.setter
+    def delta_t_physical(self, value):
+        self.is_setup = False
+        self._delta_t_physical = sympify(value)
 
     @property
     def f(self):

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2402,7 +2402,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
                 self.u.sym,
                 vtype=uw.VarType.SYM_TENSOR,
                 degree=self.u.degree - 1,
-                continuous=True,
+                continuous=False,
                 varsymbol=rf"{{F[ {self.u.symbol} ] }}",
                 verbose=self.verbose,
                 bcs=None,

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2380,7 +2380,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             self.Unknowns.DuDt = uw.systems.ddt.SemiLagrangian(
                 self.mesh,
                 self.u.sym,
-                self.bc_mask.sym[0] * self.u.sym,
+                bc_mask.sym[0] * self.u.sym,
                 vtype=uw.VarType.VECTOR,
                 degree=self.u.degree,
                 continuous=self.u.continuous,
@@ -2399,7 +2399,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             self.Unknowns.DFDt = uw.systems.ddt.SemiLagrangian(
                 self.mesh,
                 sympy.Matrix.zeros(self.mesh.dim, self.mesh.dim),
-                self.bc_mask.sym[0] * self.u.sym,
+                bc_mask.sym[0] * self.u.sym,
                 vtype=uw.VarType.SYM_TENSOR,
                 degree=self.u.degree - 1,
                 continuous=True,

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2380,7 +2380,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             self.Unknowns.DuDt = uw.systems.ddt.SemiLagrangian(
                 self.mesh,
                 self.u.sym,
-                self.u.sym * bc_mask,
+                self.bc_mask.sym[0] * self.u.sym,
                 vtype=uw.VarType.VECTOR,
                 degree=self.u.degree,
                 continuous=self.u.continuous,
@@ -2399,7 +2399,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
             self.Unknowns.DFDt = uw.systems.ddt.SemiLagrangian(
                 self.mesh,
                 sympy.Matrix.zeros(self.mesh.dim, self.mesh.dim),
-                self.u.sym * bc_mask,
+                self.bc_mask.sym[0] * self.u.sym,
                 vtype=uw.VarType.SYM_TENSOR,
                 degree=self.u.degree - 1,
                 continuous=True,


### PR DESCRIPTION
Minor adjustment to bc/s - merge all the labels from gmsh physical groups into one UW_Boundaries label with distinct numbers to represent them. 

Why ? One is that it makes the bc parsing a little bit less complicated in the solver engine. Two is that there is still a problem with the code hanging on some platforms when a label has no nodes on a process and we need to calculate surface integrals. This is much less likely with a single label ... 

Change to particle advection to identify the element-crossing time and take multiple steps when the requested time-step produces very long paths. This is helpful for accuracy near curved boundaries and also avoids skipping across multiple process boundaries in one step (still slow in DMPLEX to recover from doing that). 

All tests passing, no significant functional changes.

