### PR TITLE
Updating the interpolation routines.

### DIFF
--- a/src/underworld3/function/petsc_tools.c
+++ b/src/underworld3/function/petsc_tools.c
@@ -18,85 +18,65 @@
 
 PetscErrorCode DMInterpolationSetUp_UW(DMInterpolationInfo ctx, DM dm, PetscBool redundantPoints, PetscBool ignoreOutsideDomain, size_t *owning_cell)
 {
-  MPI_Comm comm = ctx->comm;
-  PetscScalar *a;
-  PetscInt p, q, i;
-  PetscMPIInt rank, size;
-  PetscErrorCode ierr;
-  Vec pointVec;
-  PetscLayout layout;
-  PetscReal *globalPoints;
-  PetscScalar *globalPointsScalar;
-  const PetscInt *ranges;
-  PetscMPIInt *counts, *displs;
+  MPI_Comm           comm = ctx->comm;
+  PetscScalar       *a;
+  PetscInt           p, q, i;
+  PetscMPIInt        rank, size;
+  Vec                pointVec;
+  PetscSF            cellSF;
+  PetscLayout        layout;
+  PetscReal         *globalPoints;
+  PetscScalar       *globalPointsScalar;
+  const PetscInt    *ranges;
+  PetscMPIInt       *counts, *displs;
   const PetscSFNode *foundCells;
-  const PetscInt *foundPoints;
-  PetscMPIInt *foundProcs, *globalProcs;
-  PetscInt n, N, numFound;
+  const PetscInt    *foundPoints;
+  PetscMPIInt       *foundProcs, *globalProcs;
+  PetscInt           n, N, numFound;
+  PetscErrorCode     ierr;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(dm, DM_CLASSID, 1);
-  ierr = MPI_Comm_size(comm, &size);
-  CHKERRMPI(ierr);
-  ierr = MPI_Comm_rank(comm, &rank);
-  CHKERRMPI(ierr);
-  if (ctx->dim < 0)
-    SETERRQ(comm, PETSC_ERR_ARG_WRONGSTATE, "The spatial dimension has not been set");
+  PetscValidHeaderSpecific(dm, DM_CLASSID, 2);
+  PetscCallMPI(MPI_Comm_size(comm, &size));
+  PetscCallMPI(MPI_Comm_rank(comm, &rank));
+  PetscCheck(ctx->dim >= 0, comm, PETSC_ERR_ARG_WRONGSTATE, "The spatial dimension has not been set");
   /* Locate points */
   n = ctx->nInput;
-  if (!redundantPoints)
-  {
-    ierr = PetscLayoutCreate(comm, &layout);
-    CHKERRQ(ierr);
-    ierr = PetscLayoutSetBlockSize(layout, 1);
-    CHKERRQ(ierr);
-    ierr = PetscLayoutSetLocalSize(layout, n);
-    CHKERRQ(ierr);
-    ierr = PetscLayoutSetUp(layout);
-    CHKERRQ(ierr);
-    ierr = PetscLayoutGetSize(layout, &N);
-    CHKERRQ(ierr);
+  if (!redundantPoints) {
+    PetscCall(PetscLayoutCreate(comm, &layout));
+    PetscCall(PetscLayoutSetBlockSize(layout, 1));
+    PetscCall(PetscLayoutSetLocalSize(layout, n));
+    PetscCall(PetscLayoutSetUp(layout));
+    PetscCall(PetscLayoutGetSize(layout, &N));
     /* Communicate all points to all processes */
-    ierr = PetscMalloc3(N * ctx->dim, &globalPoints, size, &counts, size, &displs);
-    CHKERRQ(ierr);
-    ierr = PetscLayoutGetRanges(layout, &ranges);
-    CHKERRQ(ierr);
-    for (p = 0; p < size; ++p)
-    {
+    PetscCall(PetscMalloc3(N * ctx->dim, &globalPoints, size, &counts, size, &displs));
+    PetscCall(PetscLayoutGetRanges(layout, &ranges));
+    for (p = 0; p < size; ++p) {
       counts[p] = (ranges[p + 1] - ranges[p]) * ctx->dim;
       displs[p] = ranges[p] * ctx->dim;
     }
-    ierr = MPI_Allgatherv(ctx->points, n * ctx->dim, MPIU_REAL, globalPoints, counts, displs, MPIU_REAL, comm);
-    CHKERRMPI(ierr);
-  }
-  else
-  {
-    N = n;
+    PetscCallMPI(MPI_Allgatherv(ctx->points, n * ctx->dim, MPIU_REAL, globalPoints, counts, displs, MPIU_REAL, comm));
+  } else {
+    N            = n;
     globalPoints = ctx->points;
     counts = displs = NULL;
-    layout = NULL;
+    layout          = NULL;
   }
 #if 0
-  ierr = PetscMalloc3(N,&foundCells,N,&foundProcs,N,&globalProcs);CHKERRQ(ierr);
+  PetscCall(PetscMalloc3(N,&foundCells,N,&foundProcs,N,&globalProcs));
   /* foundCells[p] = m->locatePoint(&globalPoints[p*ctx->dim]); */
 #else
-#if defined(PETSC_USE_COMPLEX)
-  ierr = PetscMalloc1(N * ctx->dim, &globalPointsScalar);
-  CHKERRQ(ierr);
-  for (i = 0; i < N * ctx->dim; i++)
-    globalPointsScalar[i] = globalPoints[i];
-#else
+  #if defined(PETSC_USE_COMPLEX)
+  PetscCall(PetscMalloc1(N * ctx->dim, &globalPointsScalar));
+  for (i = 0; i < N * ctx->dim; i++) globalPointsScalar[i] = globalPoints[i];
+  #else
   globalPointsScalar = globalPoints;
-#endif
-  ierr = VecCreateSeqWithArray(PETSC_COMM_SELF, ctx->dim, N * ctx->dim, globalPointsScalar, &pointVec);
-  CHKERRQ(ierr);
-  ierr = PetscMalloc2(N, &foundProcs, N, &globalProcs);
-  CHKERRQ(ierr);
-  for (p = 0; p < N; ++p)
-  {
-    foundProcs[p] = size;
-  }
-  PetscSF cellSF = NULL;
+  #endif
+  PetscCall(VecCreateSeqWithArray(PETSC_COMM_SELF, ctx->dim, N * ctx->dim, globalPointsScalar, &pointVec));
+  PetscCall(PetscMalloc2(N, &foundProcs, N, &globalProcs));
+  for (p = 0; p < N; ++p) foundProcs[p] = size;
+  cellSF = NULL;
+  /* the Underworld code is used to find good guesses for the owning cells */
   if (owning_cell)
   {
     PetscSFNode *sf_cells;
@@ -114,94 +94,61 @@ PetscErrorCode DMInterpolationSetUp_UW(DMInterpolationInfo ctx, DM dm, PetscBool
     }
     ierr = PetscSFCreate(PETSC_COMM_SELF, &cellSF);
     CHKERRQ(ierr);
+    // PETSC_OWN_POINTER => sf_cells memory control goes to cellSF
     ierr = PetscSFSetGraph(cellSF, range, N, NULL, PETSC_OWN_POINTER, sf_cells, PETSC_OWN_POINTER);
     CHKERRQ(ierr);
   }
-  ierr = DMLocatePoints(dm, pointVec, DM_POINTLOCATION_REMOVE, &cellSF);
-  CHKERRQ(ierr);
-  ierr = PetscSFGetGraph(cellSF, NULL, &numFound, &foundPoints, &foundCells);
-  CHKERRQ(ierr);
+  PetscCall(DMLocatePoints(dm, pointVec, DM_POINTLOCATION_REMOVE, &cellSF));
+  PetscCall(PetscSFGetGraph(cellSF, NULL, &numFound, &foundPoints, &foundCells));
 #endif
-  for (p = 0; p < numFound; ++p)
-  {
-    if (foundCells[p].index >= 0)
-      foundProcs[foundPoints ? foundPoints[p] : p] = rank;
+  for (p = 0; p < numFound; ++p) {
+    if (foundCells[p].index >= 0) foundProcs[foundPoints ? foundPoints[p] : p] = rank;
   }
   /* Let the lowest rank process own each point */
-  ierr = MPIU_Allreduce(foundProcs, globalProcs, N, MPI_INT, MPI_MIN, comm);
-  CHKERRQ(ierr);
+  PetscCall(MPIU_Allreduce(foundProcs, globalProcs, N, MPI_INT, MPI_MIN, comm));
   ctx->n = 0;
-  for (p = 0; p < N; ++p)
-  {
-    if (globalProcs[p] == size)
-    {
-      if (!ignoreOutsideDomain)
-        SETERRQ4(comm, PETSC_ERR_PLIB, "Point %d: %g %g %g not located in mesh", p, (double)globalPoints[p * ctx->dim + 0], (double)(ctx->dim > 1 ? globalPoints[p * ctx->dim + 1] : 0.0), (double)(ctx->dim > 2 ? globalPoints[p * ctx->dim + 2] : 0.0));
-      else if (!rank)
-        ++ctx->n;
-    }
-    else if (globalProcs[p] == rank)
-      ++ctx->n;
+  for (p = 0; p < N; ++p) {
+    if (globalProcs[p] == size) {
+      PetscCheck(ignoreOutsideDomain, comm, PETSC_ERR_PLIB, "Point %" PetscInt_FMT ": %g %g %g not located in mesh", p, (double)globalPoints[p * ctx->dim + 0], (double)(ctx->dim > 1 ? globalPoints[p * ctx->dim + 1] : 0.0),
+                 (double)(ctx->dim > 2 ? globalPoints[p * ctx->dim + 2] : 0.0));
+      if (rank == 0) ++ctx->n;
+    } else if (globalProcs[p] == rank) ++ctx->n;
   }
   /* Create coordinates vector and array of owned cells */
-  ierr = PetscMalloc1(ctx->n, &ctx->cells);
-  CHKERRQ(ierr);
-  ierr = VecCreate(comm, &ctx->coords);
-  CHKERRQ(ierr);
-  ierr = VecSetSizes(ctx->coords, ctx->n * ctx->dim, PETSC_DECIDE);
-  CHKERRQ(ierr);
-  ierr = VecSetBlockSize(ctx->coords, ctx->dim);
-  CHKERRQ(ierr);
-  ierr = VecSetType(ctx->coords, VECSTANDARD);
-  CHKERRQ(ierr);
-  ierr = VecGetArray(ctx->coords, &a);
-  CHKERRQ(ierr);
-  for (p = 0, q = 0, i = 0; p < N; ++p)
-  {
-    if (globalProcs[p] == rank)
-    {
+  PetscCall(PetscMalloc1(ctx->n, &ctx->cells));
+  PetscCall(VecCreate(comm, &ctx->coords));
+  PetscCall(VecSetSizes(ctx->coords, ctx->n * ctx->dim, PETSC_DECIDE));
+  PetscCall(VecSetBlockSize(ctx->coords, ctx->dim));
+  PetscCall(VecSetType(ctx->coords, VECSTANDARD));
+  PetscCall(VecGetArray(ctx->coords, &a));
+  for (p = 0, q = 0, i = 0; p < N; ++p) {
+    if (globalProcs[p] == rank) {
       PetscInt d;
 
-      for (d = 0; d < ctx->dim; ++d, ++i)
-        a[i] = globalPoints[p * ctx->dim + d];
+      for (d = 0; d < ctx->dim; ++d, ++i) a[i] = globalPoints[p * ctx->dim + d];
       ctx->cells[q] = foundCells[q].index;
       ++q;
     }
-    if (globalProcs[p] == size && !rank)
-    {
+    if (globalProcs[p] == size && rank == 0) {
       PetscInt d;
 
-      for (d = 0; d < ctx->dim; ++d, ++i)
-        a[i] = 0.;
+      for (d = 0; d < ctx->dim; ++d, ++i) a[i] = 0.;
       ctx->cells[q] = -1;
       ++q;
     }
   }
-  ierr = VecRestoreArray(ctx->coords, &a);
-  CHKERRQ(ierr);
+  PetscCall(VecRestoreArray(ctx->coords, &a));
 #if 0
-  ierr = PetscFree3(foundCells,foundProcs,globalProcs);CHKERRQ(ierr);
+  PetscCall(PetscFree3(foundCells,foundProcs,globalProcs));
 #else
-  ierr = PetscFree2(foundProcs, globalProcs);
-  CHKERRQ(ierr);
-  ierr = PetscSFDestroy(&cellSF);
-  CHKERRQ(ierr);
-  ierr = VecDestroy(&pointVec);
-  CHKERRQ(ierr);
+  PetscCall(PetscFree2(foundProcs, globalProcs));
+  PetscCall(PetscSFDestroy(&cellSF));
+  PetscCall(VecDestroy(&pointVec));
 #endif
-  if ((void *)globalPointsScalar != (void *)globalPoints)
-  {
-    ierr = PetscFree(globalPointsScalar);
-    CHKERRQ(ierr);
-  }
-  if (!redundantPoints)
-  {
-    ierr = PetscFree3(globalPoints, counts, displs);
-    CHKERRQ(ierr);
-  }
-  ierr = PetscLayoutDestroy(&layout);
-  CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+  if ((void *)globalPointsScalar != (void *)globalPoints) PetscCall(PetscFree(globalPointsScalar));
+  if (!redundantPoints) PetscCall(PetscFree3(globalPoints, counts, displs));
+  PetscCall(PetscLayoutDestroy(&layout));
+  PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 /*@C
@@ -223,122 +170,118 @@ PetscErrorCode DMInterpolationSetUp_UW(DMInterpolationInfo ctx, DM dm, PetscBool
 @*/
 PetscErrorCode DMInterpolationEvaluate_UW(DMInterpolationInfo ctx, DM dm, Vec x, Vec v)
 {
-  PetscInt n;
-  PetscErrorCode ierr;
+  PetscDS   ds;
+  PetscInt  n, p, Nf, field;
+  PetscBool useDS = PETSC_FALSE;
 
   PetscFunctionBegin;
   PetscValidHeaderSpecific(dm, DM_CLASSID, 2);
   PetscValidHeaderSpecific(x, VEC_CLASSID, 3);
   PetscValidHeaderSpecific(v, VEC_CLASSID, 4);
-  ierr = VecGetLocalSize(v, &n);
-  CHKERRQ(ierr);
-  if (n != ctx->n * ctx->dof)
-    SETERRQ2(ctx->comm, PETSC_ERR_ARG_SIZ, "Invalid input vector size %D should be %D", n, ctx->n * ctx->dof);
-  if (n)
-  {
-    PetscDS ds;
-    // PetscBool      done = PETSC_FALSE;
+  PetscCall(VecGetLocalSize(v, &n));
+  PetscCheck(n == ctx->n * ctx->dof, ctx->comm, PETSC_ERR_ARG_SIZ, "Invalid input vector size %" PetscInt_FMT " should be %" PetscInt_FMT, n, ctx->n * ctx->dof);
+  if (!n) PetscFunctionReturn(PETSC_SUCCESS);
+  PetscCall(DMGetDS(dm, &ds));
+  if (ds) {
+    useDS = PETSC_TRUE;
+    PetscCall(PetscDSGetNumFields(ds, &Nf));
+    for (field = 0; field < Nf; ++field) {
+      PetscObject  obj;
+      PetscClassId id;
 
-    ierr = DMGetDS(dm, &ds);
-    CHKERRQ(ierr);
-    if (ds)
-    {
-      const PetscScalar *coords;
-      PetscScalar *interpolant;
-      PetscInt cdim, d, p, Nf, field;
+      PetscCall(PetscDSGetDiscretization(ds, field, &obj));
+      PetscCall(PetscObjectGetClassId(obj, &id));
+      if (id != PETSCFE_CLASSID && id != PETSCFV_CLASSID) {
+        useDS = PETSC_FALSE;
+        break;
+      }
+    }
+  }
+  if (useDS) {
+    const PetscScalar *coords;
+    PetscScalar       *interpolant;
+    PetscInt           cdim, d;
 
-      ierr = VecGetArrayRead(ctx->coords, &coords);
-      CHKERRQ(ierr);
-      ierr = VecGetArrayWrite(v, &interpolant);
-      CHKERRQ(ierr);
+    PetscCall(DMGetCoordinateDim(dm, &cdim));
+    PetscCall(VecGetArrayRead(ctx->coords, &coords));
+    PetscCall(VecGetArrayWrite(v, &interpolant));
+    for (p = 0; p < ctx->n; ++p) {
+      PetscReal    pcoords[3], xi[3];
+      PetscScalar *xa   = NULL;
+      PetscInt     coff = 0, foff = 0, clSize;
 
-      ierr = DMGetCoordinateDim(dm, &cdim);
-      CHKERRQ(ierr);
-      ierr = PetscDSGetNumFields(ds, &Nf);
-      CHKERRQ(ierr);
+      if (ctx->cells[p] < 0) continue;
+      for (d = 0; d < cdim; ++d) pcoords[d] = PetscRealPart(coords[p * cdim + d]);
+      PetscCall(DMPlexCoordinatesToReference(dm, ctx->cells[p], 1, pcoords, xi));
+      PetscCall(DMPlexVecGetClosure(dm, NULL, x, ctx->cells[p], &clSize, &xa));
+      for (field = 0; field < Nf; ++field) {
+        PetscTabulation T;
+        PetscObject     obj;
+        PetscClassId    id;
 
-      for (p = 0; p < ctx->n; ++p)
-      {
-        PetscReal xi[3];
-        PetscScalar *xa = NULL;
-        PetscReal pcoords[3];
-        PetscInt c;
+        PetscCall(PetscDSGetDiscretization(ds, field, &obj));
+        PetscCall(PetscObjectGetClassId(obj, &id));
+        if (id == PETSCFE_CLASSID) {
+          PetscFE fe = (PetscFE)obj;
 
-        if (ctx->cells[p] < 0)
-          continue;
-        for (d = 0; d < cdim; ++d)
-          pcoords[d] = PetscRealPart(coords[p * cdim + d]);
-        ierr = DMPlexCoordinatesToReference(dm, ctx->cells[p], 1, pcoords, xi);
-        CHKERRQ(ierr);
-        ierr = DMPlexVecGetClosure(dm, NULL, x, ctx->cells[p], NULL, &xa);
-        CHKERRQ(ierr);
-
-        PetscInt d = 0;
-
-        c = 0;
-
-        for (field = 0; field < Nf; ++field)
-        {
-          PetscTabulation T;
-          PetscFE fe;
-          PetscClassId id;
-          PetscInt Nc, f, fc;
-
-          ierr = PetscDSGetDiscretization(ds, field, (PetscObject *)&fe);
-          CHKERRQ(ierr);
-          ierr = PetscObjectGetClassId((PetscObject)fe, &id);
-          CHKERRQ(ierr);
-          if (id != PETSCFE_CLASSID)
-            break;
-          ierr = PetscFEGetNumComponents(fe, &Nc);
-          CHKERRQ(ierr);
-
-          ierr = PetscFECreateTabulation(fe, 1, 1, xi, 0, &T);
-          CHKERRQ(ierr);
+          PetscCall(PetscFECreateTabulation(fe, 1, 1, xi, 0, &T));
           {
             const PetscReal *basis = T->T[0];
-            const PetscInt Nb = T->Nb;
-            const PetscInt Nc = T->Nc;
-            for (fc = 0; fc < Nc; ++fc)
-            {
-              interpolant[p * ctx->dof + c + fc] = 0.0;
-              for (f = 0; f < Nb; ++f)
-              {
-                interpolant[p * ctx->dof + c + fc] += xa[d + f] * basis[(0 * Nb + f) * Nc + fc];
-              }
+            const PetscInt   Nb    = T->Nb;
+            const PetscInt   Nc    = T->Nc;
+
+            for (PetscInt fc = 0; fc < Nc; ++fc) {
+              interpolant[p * ctx->dof + coff + fc] = 0.0;
+              for (PetscInt f = 0; f < Nb; ++f) interpolant[p * ctx->dof + coff + fc] += xa[foff + f] * basis[(0 * Nb + f) * Nc + fc];
             }
-            d += Nb;
+            coff += Nc;
+            foff += Nb;
           }
-          ierr = PetscTabulationDestroy(&T);
-          CHKERRQ(ierr);
-          c += Nc;
+          PetscCall(PetscTabulationDestroy(&T));
+        } else if (id == PETSCFV_CLASSID) {
+          PetscFV  fv = (PetscFV)obj;
+          PetscInt Nc;
+
+          // TODO Could use reconstruction if available
+          PetscCall(PetscFVGetNumComponents(fv, &Nc));
+          for (PetscInt fc = 0; fc < Nc; ++fc) interpolant[p * ctx->dof + coff + fc] = xa[foff + fc];
+          coff += Nc;
+          foff += Nc;
         }
-        if (field == Nf)
-        {
-          // done = PETSC_TRUE;
-          if (c != ctx->dof)
-            SETERRQ2(PETSC_COMM_SELF, PETSC_ERR_PLIB, "Total components %D != %D dof specified for interpolation", c, ctx->dof);
-        }
-        ierr = DMPlexVecRestoreClosure(dm, NULL, x, ctx->cells[p], NULL, &xa);
-        CHKERRQ(ierr);
       }
-      ierr = VecRestoreArrayWrite(v, &interpolant);
-      CHKERRQ(ierr);
-      ierr = VecRestoreArrayRead(ctx->coords, &coords);
-      CHKERRQ(ierr);
+      PetscCall(DMPlexVecRestoreClosure(dm, NULL, x, ctx->cells[p], &clSize, &xa));
+      PetscCheck(coff == ctx->dof, PETSC_COMM_SELF, PETSC_ERR_PLIB, "Total components %" PetscInt_FMT " != %" PetscInt_FMT " dof specified for interpolation", coff, ctx->dof);
+      PetscCheck(foff == clSize, PETSC_COMM_SELF, PETSC_ERR_PLIB, "Total FE/FV space size %" PetscInt_FMT " != %" PetscInt_FMT " closure size", foff, clSize);
     }
-    // if (!done) {
+    PetscCall(VecRestoreArrayRead(ctx->coords, &coords));
+    PetscCall(VecRestoreArrayWrite(v, &interpolant));
+  } else {
+    PetscAssert(0,PETSC_COMM_WORLD, 1, "Underworld3 interpolation code shouldn't reach here");
+    // for (PetscInt p = 0; p < ctx->n; ++p) {
+    //   const PetscInt cell = ctx->cells[p];
     //   DMPolytopeType ct;
-    //   /* TODO Check each cell individually */
-    //   ierr = DMPlexGetCellType(dm, ctx->cells[0], &ct);CHKERRQ(ierr);
+
+    //   PetscCall(DMPlexGetCellType(dm, cell, &ct));
     //   switch (ct) {
-    //     case DM_POLYTOPE_TRIANGLE:      ierr = DMInterpolate_Triangle_Private(ctx, dm, x, v);CHKERRQ(ierr);break;
-    //     case DM_POLYTOPE_QUADRILATERAL: ierr = DMInterpolate_Quad_Private(ctx, dm, x, v);CHKERRQ(ierr);break;
-    //     case DM_POLYTOPE_TETRAHEDRON:   ierr = DMInterpolate_Tetrahedron_Private(ctx, dm, x, v);CHKERRQ(ierr);break;
-    //     case DM_POLYTOPE_HEXAHEDRON:    ierr = DMInterpolate_Hex_Private(ctx, dm, x, v);CHKERRQ(ierr);break;
-    //     default: SETERRQ1(PETSC_COMM_SELF, PETSC_ERR_SUP, "No support fpr cell type %s", DMPolytopeTypes[ct]);
+    //   case DM_POLYTOPE_SEGMENT:
+    //     PetscCall(DMInterpolate_Segment_Private(ctx, dm, p, x, v));
+    //     break;
+    //   case DM_POLYTOPE_TRIANGLE:
+    //     PetscCall(DMInterpolate_Triangle_Private(ctx, dm, p, x, v));
+    //     break;
+    //   case DM_POLYTOPE_QUADRILATERAL:
+    //     PetscCall(DMInterpolate_Quad_Private(ctx, dm, p, x, v));
+    //     break;
+    //   case DM_POLYTOPE_TETRAHEDRON:
+    //     PetscCall(DMInterpolate_Tetrahedron_Private(ctx, dm, p, x, v));
+    //     break;
+    //   case DM_POLYTOPE_HEXAHEDRON:
+    //     PetscCall(DMInterpolate_Hex_Private(ctx, dm, cell, x, v));
+    //     break;
+    //   default:
+    //     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP, "No support for cell type %s", DMPolytopeTypes[PetscMax(0, PetscMin(ct, DM_NUM_POLYTOPES))]);
     //   }
     // }
   }
-  PetscFunctionReturn(0);
+  PetscFunctionReturn(PETSC_SUCCESS);
 }


### PR DESCRIPTION
These c functions are direct copies of the petsc routines DMInterpolation_SetUp and DMInterpolation_Evaluate, only with owning_cell information provided and used. Until petsc can optionally use 'owning_cells' we will have to manually update the c code like this commit.