### PR TITLE
fix pyvista issue in binder

### DIFF
--- a/src/underworld3/visualisation.py
+++ b/src/underworld3/visualisation.py
@@ -1,5 +1,5 @@
 ## pyvista helper routines
-
+import os
 
 def initialise():
 
@@ -12,7 +12,10 @@ def initialise():
     pv.global_theme.camera["position"] = [0.0, 0.0, 5.0]
 
     try:
-        pv.global_theme.jupyter_backend = "trame"
+        if 'BINDER_LAUNCH_HOST' in os.environ or 'BINDER_REPO_URL' in os.environ:
+            pv.global_theme.jupyter_backend = "client"
+        else:
+            pv.global_theme.jupyter_backend = "trame"
     except RuntimeError:
         pv.global_theme.jupyter_backend = "panel"
 


### PR DESCRIPTION
Hi,

I have created a fix for the binder pyvista issue.
First, we check whether pyvista is running on binder or not then set `pv.global_theme.jupyter_backend = "trame" or "client"` accordingly.