### PR TITLE
UWexpressions `value` -> `sym`

### DIFF
--- a/src/underworld3/constitutive_models.py
+++ b/src/underworld3/constitutive_models.py
@@ -1508,9 +1508,10 @@ class DarcyFlowModel(Constitutive_Model):
 
             inner_self._s = expression(
                 R"{s}",
-                0,
+                sympy.Matrix.zeros(rows=1, cols=_owning_model.dim),
                 "Gravitational forcing",
             )
+            print(f"Owning model is:{_owning_model} and it's dim is {_owning_model.dim}")
 
             inner_self._permeability = expression(
                 R"{\kappa}",
@@ -1581,7 +1582,7 @@ class DarcyFlowModel(Constitutive_Model):
         may be required to evaluate the flux.
         """
 
-        ddu = self.grad_u - self.Parameters.s
+        ddu = self.grad_u - self.Parameters.s.sym
 
         return self._q(ddu)
 

--- a/src/underworld3/constitutive_models.py
+++ b/src/underworld3/constitutive_models.py
@@ -1511,7 +1511,6 @@ class DarcyFlowModel(Constitutive_Model):
                 sympy.Matrix.zeros(rows=1, cols=_owning_model.dim),
                 "Gravitational forcing",
             )
-            print(f"Owning model is:{_owning_model} and it's dim is {_owning_model.dim}")
 
             inner_self._permeability = expression(
                 R"{\kappa}",
@@ -1527,7 +1526,7 @@ class DarcyFlowModel(Constitutive_Model):
 
         @s.setter
         def s(inner_self, value: sympy.Matrix):
-            inner_self._s = value
+            inner_self._s.sym = value
             inner_self._reset()
 
         @property

--- a/src/underworld3/constitutive_models.py
+++ b/src/underworld3/constitutive_models.py
@@ -344,7 +344,7 @@ class ViscousFlowModel(Constitutive_Model):
         ):
 
             inner_self._owning_model = _owning_model
-            inner_self._shear_viscosity_0 = expression("\eta", 1, "Shear viscosity")
+            inner_self._shear_viscosity_0 = expression(r"\eta", 1, "Shear viscosity")
 
         @property
         def shear_viscosity_0(inner_self):
@@ -445,7 +445,7 @@ class ViscousFlowModel(Constitutive_Model):
         display(
             Latex(
                 r"$\quad\eta_\textrm{eff} = $ "
-                + sympy.sympify(self.viscosity.value)._repr_latex_()
+                + sympy.sympify(self.viscosity.sym)._repr_latex_()
             )
         )
 
@@ -625,13 +625,13 @@ class ViscoPlasticFlowModel(ViscousFlowModel):
         inner_self = self.Parameters
         # detect if values we need are defined or are placeholder symbols
 
-        if inner_self.yield_stress.value == sympy.oo:
+        if inner_self.yield_stress.sym == sympy.oo:
             return inner_self._shear_viscosity_0
 
         # Don't put conditional behaviour in the constitutive law
         # when it is not needed
 
-        if inner_self.yield_stress_min.value is not 0:
+        if inner_self.yield_stress_min.sym != 0:
             yield_stress = sympy.Max(
                 inner_self.yield_stress_min, inner_self.yield_stress
             )
@@ -660,7 +660,7 @@ class ViscoPlasticFlowModel(ViscousFlowModel):
         # If we want to apply limits to the viscosity but see caveat above
         # Keep this as an sub-expression for clarity
 
-        if inner_self.shear_viscosity_min.value != -sympy.oo:
+        if inner_self.shear_viscosity_min.sym != -sympy.oo:
             effective_viscosity_ltd = uw.function.expression(
                 R"{\eta_\textrm{eff,p}}",
                 sympy.simplify(
@@ -707,11 +707,11 @@ class ViscoPlasticFlowModel(ViscousFlowModel):
         display(
             Latex(
                 r"$\quad\eta_\textrm{0} = $"
-                + sympy.sympify(self.Parameters.shear_viscosity_0.value)._repr_latex_()
+                + sympy.sympify(self.Parameters.shear_viscosity_0.sym)._repr_latex_()
             ),
             Latex(
                 r"$\quad\tau_\textrm{y} = $"
-                + sympy.sympify(self.Parameters.yield_stress.value)._repr_latex_(),
+                + sympy.sympify(self.Parameters.yield_stress.sym)._repr_latex_(),
             ),
         )
 
@@ -745,28 +745,28 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
 
         # This may not be defined at initialisation time, set to None until used
         self._stress_star = expression(
-            R"{\tau^{*}}",
+            r"{\tau^{*}}",
             None,
-            "Lagrangian Stress at $t - \delta_t$",
+            r"Lagrangian Stress at $t - \delta_t$",
         )
 
         # This may not be defined at initialisation time, set to None until used
         self._stress_2star = expression(
-            R"{\tau^{**}}",
+            r"{\tau^{**}}",
             None,
-            "Lagrangian Stress at $t - 2\delta_t$",
+            r"Lagrangian Stress at $t - 2\delta_t$",
         )
 
         # This may not be well-defined at initialisation time, set to None until used
         self._E_eff = expression(
-            R"{\dot{\varepsilon}_{\textrm{eff}}}",
+            r"{\dot{\varepsilon}_{\textrm{eff}}}",
             None,
             "Equivalent value of strain rate (accounting for stress history)",
         )
 
         # This may not be well-defined at initialisation time, set to None until used
         self._E_eff_inv_II = expression(
-            R"{\dot{\varepsilon}_{II,\textrm{eff}}}",
+            r"{\dot{\varepsilon}_{II,\textrm{eff}}}",
             None,
             "Equivalent value of strain rate 2nd invariant (accounting for stress history)",
         )
@@ -998,7 +998,7 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
                     )
                 )
 
-            inner_self._ve_effective_viscosity.value = el_eff_visc
+            inner_self._ve_effective_viscosity.sym = el_eff_visc
 
             return inner_self._ve_effective_viscosity
 
@@ -1007,7 +1007,7 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
             # shear modulus defaults to infinity so t_relax goes to zero
             # in the viscous limit
 
-            inner_self._t_relax.value = (
+            inner_self._t_relax.sym = (
                 inner_self.shear_viscosity_0 / inner_self.shear_modulus
             )
             return inner_self._t_relax
@@ -1028,7 +1028,7 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
     @property
     def stress_star(self):
         if self.Unknowns.DFDt is not None:
-            self._stress_star.value = self.Unknowns.DFDt.psi_star[0].sym
+            self._stress_star.sym = self.Unknowns.DFDt.psi_star[0].sym
 
         return self._stress_star
 
@@ -1039,9 +1039,9 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
 
         if self.Unknowns.DFDt is not None:
             if self.Unknowns.DFDt.order >= 2:
-                self._stress_2star.value = self.Unknowns.DFDt.psi_star[1].sym
+                self._stress_2star.sym = self.Unknowns.DFDt.psi_star[1].sym
             else:
-                self._stress_2star.value = sympy.sympify(0)
+                self._stress_2star.sym = sympy.sympify(0)
 
         return self._stress_2star
 
@@ -1068,15 +1068,15 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
                         4 * self.Parameters.dt_elastic * self.Parameters.shear_modulus
                     )
 
-        self._E_eff.value = E
+        self._E_eff.sym = E
 
         return self._E_eff
 
     @property
     def E_eff_inv_II(self):
 
-        E_eff = self.E_eff.value
-        self._E_eff_inv_II.value = sympy.sqrt((E_eff**2).trace() / 2)
+        E_eff = self.E_eff.sym
+        self._E_eff_inv_II.sym = sympy.sqrt((E_eff**2).trace() / 2)
 
         return self._E_eff_inv_II
 
@@ -1093,7 +1093,7 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
 
         inner_self = self.Parameters
 
-        if inner_self.yield_stress.value == sympy.oo:
+        if inner_self.yield_stress.sym == sympy.oo:
             return inner_self.ve_effective_viscosity
 
         effective_viscosity = inner_self.ve_effective_viscosity
@@ -1110,7 +1110,7 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
 
         # If we want to apply limits to the viscosity but see caveat above
 
-        if inner_self.shear_viscosity_min.value != -sympy.oo:
+        if inner_self.shear_viscosity_min.sym != -sympy.oo:
             return sympy.Max(
                 effective_viscosity,
                 inner_self.shear_viscosity_min,
@@ -1143,14 +1143,14 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
             "Strain rate 2nd Invariant including elastic strain rate term",
         )
 
-        if parameters.yield_stress_min.value != 0:
+        if parameters.yield_stress_min.sym != 0:
             yield_stress = sympy.Max(
                 parameters.yield_stress_min, parameters.yield_stress
             )  # .rewrite(sympy.Piecewise)
         else:
             yield_stress = parameters.yield_stress
 
-        if parameters.strainrate_inv_II_min.value != 0:
+        if parameters.strainrate_inv_II_min.sym != 0:
             viscosity_yield = yield_stress / (
                 2 * (strainrate_inv_II + parameters.strainrate_inv_II_min)
             )
@@ -1336,7 +1336,7 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
         display(
             Latex(
                 r"$\quad\eta_\textrm{0} = $ "
-                + sympy.sympify(self.Parameters.shear_viscosity_0.value)._repr_latex_()
+                + sympy.sympify(self.Parameters.shear_viscosity_0.sym)._repr_latex_()
             ),
         )
 
@@ -1344,11 +1344,11 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
         display(
             Latex(
                 r"$\quad\mu = $ "
-                + sympy.sympify(self.Parameters.shear_modulus.value)._repr_latex_(),
+                + sympy.sympify(self.Parameters.shear_modulus.sym)._repr_latex_(),
             ),
             Latex(
                 r"$\quad\Delta t_e = $ "
-                + sympy.sympify(self.Parameters.dt_elastic.value)._repr_latex_(),
+                + sympy.sympify(self.Parameters.dt_elastic.sym)._repr_latex_(),
             ),
         )
 
@@ -1356,7 +1356,7 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
         display(
             Latex(
                 r"$\quad\tau_\textrm{y} = $ "
-                + sympy.sympify(self.Parameters.yield_stress.value)._repr_latex_(),
+                + sympy.sympify(self.Parameters.yield_stress.sym)._repr_latex_(),
             )
             ## Todo: add all the other properties in here
         )
@@ -1365,10 +1365,10 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
     def is_elastic(self):
         # If any of these is not defined, elasticity is switched off
 
-        if self.Parameters.dt_elastic.value is sympy.oo:
+        if self.Parameters.dt_elastic.sym is sympy.oo:
             return False
 
-        if self.Parameters.shear_modulus.value is sympy.oo:
+        if self.Parameters.shear_modulus.sym is sympy.oo:
             return False
 
         return True

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -722,8 +722,8 @@ class SNES_Scalar(SolverBaseClass):
         # f0 = sympy.Array(self._f0).reshape(1).as_immutable()
         # F1 = sympy.Array(self._f1).reshape(dim).as_immutable()
 
-        f0  = sympy.Array(uw.function.fn_substitute_expressions(self.F0.value)).reshape(1).as_immutable()
-        F1  = sympy.Array(uw.function.fn_substitute_expressions(self.F1.value)).reshape(dim).as_immutable()
+        f0  = sympy.Array(uw.function.fn_substitute_expressions(self.F0.sym)).reshape(1).as_immutable()
+        F1  = sympy.Array(uw.function.fn_substitute_expressions(self.F1.sym)).reshape(dim).as_immutable()
 
         self._u_f0 = f0
         self._u_F1 = F1
@@ -987,8 +987,8 @@ class SNES_Scalar(SolverBaseClass):
         from IPython.display import Latex, Markdown, display
         from textwrap import dedent
 
-        f0 = self.F0.value
-        F1 = self.F1.value
+        f0 = self.F0.sym
+        F1 = self.F1.sym
 
         eqF1 = "$\\tiny \\quad \\nabla \\cdot \\color{Blue}" + sympy.latex( F1 )+"$ + "
         eqf0 = "$\\tiny \\phantom{ \\quad \\nabla \\cdot} \\color{DarkRed}" + sympy.latex( f0 )+"\\color{Black} = 0 $"
@@ -1336,8 +1336,8 @@ class SNES_Vector(SolverBaseClass):
         # f0 = sympy.Array(self._f0).reshape(1).as_immutable()
         # F1 = sympy.Array(self._f1).reshape(dim).as_immutable()
 
-        f0  = sympy.Array(uw.function.fn_substitute_expressions(self.F0.value)).reshape(dim).as_immutable()
-        F1  = sympy.Array(uw.function.fn_substitute_expressions(self.F1.value)).reshape(dim,dim).as_immutable()
+        f0  = sympy.Array(uw.function.fn_substitute_expressions(self.F0.sym)).reshape(dim).as_immutable()
+        F1  = sympy.Array(uw.function.fn_substitute_expressions(self.F1.sym)).reshape(dim,dim).as_immutable()
 
         self._u_f0 = f0
         self._u_F1 = F1
@@ -1670,8 +1670,8 @@ class SNES_Vector(SolverBaseClass):
         from IPython.display import Latex, Markdown, display
         from textwrap import dedent
 
-        f0 = self.F0.value
-        F1 = self.F1.value
+        f0 = self.F0.sym
+        F1 = self.F1.sym
 
         eqF1 = "$\\tiny \\quad \\nabla \\cdot \\color{Blue}" + sympy.latex( F1 )+"$ + "
         eqf0 = "$\\tiny \\phantom{ \\quad \\nabla \\cdot} \\color{DarkRed}" + sympy.latex( f0 )+"\\color{Black} = 0 $"
@@ -2065,12 +2065,12 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         from IPython.display import Latex, Markdown, display
         from textwrap import dedent
 
-        uf0 = self.F0.value
-        uF1 = self.F1.value
-        pF0 = self.PF0.value
+        uf0 = self.F0.sym
+        uF1 = self.F1.sym
+        pF0 = self.PF0.sym
 
-        if self.penalty.value == 0:
-            uF1 = self.F1.value.subs(self.penalty, self.penalty.value)
+        if self.penalty.sym == 0:
+            uF1 = self.F1.sym.subs(self.penalty, self.penalty.sym)
 
         eqF1 = "$\\tiny \\quad \\nabla \\cdot \\color{Blue}" + sympy.latex( uF1 )+"$ + "
         eqf0 = "$\\tiny \\phantom{ \\quad \\nabla \\cdot} \\color{DarkRed}" + sympy.latex( uf0 )+"\\color{Black} = 0 $"
@@ -2177,9 +2177,9 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         ## is working .. so be careful !!
 
 
-        F0  = sympy.Array(uw.function.fn_substitute_expressions(self.F0.value))
-        F1  = sympy.Array(uw.function.fn_substitute_expressions(self.F1.value))
-        PF0 = sympy.Array(uw.function.fn_substitute_expressions(self.PF0.value))
+        F0  = sympy.Array(uw.function.fn_substitute_expressions(self.F0.sym))
+        F1  = sympy.Array(uw.function.fn_substitute_expressions(self.F1.sym))
+        PF0 = sympy.Array(uw.function.fn_substitute_expressions(self.PF0.sym))
 
         # JIT compilation needs immutable, matrix input (not arrays)
         self._u_F0 = sympy.ImmutableDenseMatrix(F0)

--- a/src/underworld3/function/expressions.py
+++ b/src/underworld3/function/expressions.py
@@ -90,7 +90,7 @@ class UWexpression(Symbol, uw_object):
                         value=3.0e-5,
                         description="thermal expansivity"
                             )
-        print(alpha.value)
+        print(alpha.sym)
         print(alpha.description)
     ```
 
@@ -235,7 +235,7 @@ class UWexpression(Symbol, uw_object):
             display(
                 Latex(
                     r"$"
-                    + "\quad" * level
+                    + r"\quad" * level
                     + "$"
                     + self._repr_latex_()
                     + "$=$"
@@ -246,7 +246,7 @@ class UWexpression(Symbol, uw_object):
                 display(
                     Markdown(
                         r"$"
-                        + "\quad" * level
+                        + r"\quad" * level
                         + "$"
                         + f"**Description:**  {self.description}"
                     ),

--- a/src/underworld3/function/expressions.py
+++ b/src/underworld3/function/expressions.py
@@ -7,17 +7,17 @@ def _substitute_all_once(fn, keep_constants=True, return_self=True):
 
     if keep_constants and return_self and is_constant_expr(fn):
         if isinstance(fn, UWexpression):
-            return fn.value
+            return fn.sym
         else:
             return fn
 
     expr = fn
     for atom in fn.atoms():
         if isinstance(atom, UWexpression):
-            if keep_constants and isinstance(atom.value, (float, int, Number)):
+            if keep_constants and isinstance(atom.sym, (float, int, Number)):
                 continue
             else:
-                expr = expr.subs(atom, atom.value)
+                expr = expr.subs(atom, atom.sym)
 
     return expr
 
@@ -27,16 +27,16 @@ def _substitute_one_expr(fn, sub_expr, keep_constants=True, return_self=True):
 
     if keep_constants and return_self and is_constant_expr(fn):
         if isinstance(fn, UWexpression):
-            return fn.value
+            return fn.sym
         else:
             return fn
 
     for atom in fn.atoms():
         if atom is sub_expr:
-            if keep_constants and isinstance(atom.value, (float, int, Number)):
+            if keep_constants and isinstance(atom.sym, (float, int, Number)):
                 continue
             else:
-                expr = expr.subs(atom, atom.value)
+                expr = expr.subs(atom, atom.sym)
 
     return expr
 
@@ -66,7 +66,7 @@ def is_constant_expr(fn):
     deps = extract_expressions(fn)
 
     for dep in deps:
-        if not isinstance(dep.value, (float, int, sympy.Number)):
+        if not isinstance(dep.sym, (float, int, sympy.Number)):
             return False
 
         return True
@@ -99,13 +99,13 @@ class UWexpression(Symbol, uw_object):
     def __new__(cls, name, value, description="No description provided"):
 
         obj = Symbol.__new__(cls, name)
-        obj.value = sympy.sympify(value)
+        obj.sym = sympy.sympify(value)
         obj.symbol = name
         return obj
 
     def __init__(self, name, value, description="No description provided"):
 
-        self._value = sympy.sympify(value)
+        self._sym = sympy.sympify(value)
         self._description = description
 
         return
@@ -115,7 +115,7 @@ class UWexpression(Symbol, uw_object):
             raise ValueError
         else:
             self.symbol = other.symbol
-            self.value = other.value
+            self.sym = other.sym
             self.description = other.description
 
         return
@@ -125,18 +125,33 @@ class UWexpression(Symbol, uw_object):
         deps = self.dependencies()
 
         for dep in deps:
-            if not isinstance(dep.value, (float, int, sympy.Number)):
+            if not isinstance(dep.sym, (float, int, sympy.Number)):
                 return False
 
         return True
 
     @property
+    def sym(self):
+        return self._sym
+
+    @sym.setter
+    def sym(self, new_value):
+        self._sym = sympy.sympify(new_value)
+        return
+
+    #TODO: DEPRECATION
+    # The value attribute is no longer needed in the offical release of Underworld3
+    @property
     def value(self):
-        return self._value
+        import warnings
+        warnings.warn(message=f"DEPRECATION warning, don't use 'value' attribute for expression: {self}, please use 'sym' attribute")
+        return self._sym
 
     @value.setter
     def value(self, new_value):
-        self._value = sympy.sympify(new_value)
+        import warnings
+        warnings.warn(message=f"DEPRECATION warning, don't use 'value' attribute for expression: {new_value}, please use 'sym' attribute")
+        self._sym = sympy.sympify(new_value)
         return
 
     @property
@@ -163,11 +178,11 @@ class UWexpression(Symbol, uw_object):
         return self_s
 
     def dependencies(self, keep_constants=True):
-        subbed_expr = substitute(self.value, keep_constants=keep_constants)
+        subbed_expr = substitute(self.sym, keep_constants=keep_constants)
         return subbed_expr.atoms(sympy.Symbol)
 
     def all_dependencies(self, keep_constants=True):
-        subbed_expr = substitute(self.value, keep_constants=keep_constants)
+        subbed_expr = substitute(self.sym, keep_constants=keep_constants)
         return subbed_expr.atoms(sympy.Symbol, sympy.Function)
 
     # def _substitute_all_once(fn, keep_constants=True):
@@ -216,7 +231,7 @@ class UWexpression(Symbol, uw_object):
         level = max(1, level)
 
         ## feedback on this instance
-        if sympy.sympify(self.value) is not None:
+        if sympy.sympify(self.sym) is not None:
             display(
                 Latex(
                     r"$"
@@ -224,7 +239,7 @@ class UWexpression(Symbol, uw_object):
                     + "$"
                     + self._repr_latex_()
                     + "$=$"
-                    + sympy.sympify(self.value)._repr_latex_()
+                    + sympy.sympify(self.sym)._repr_latex_()
                 ),
             )
             if description == True:
@@ -238,9 +253,9 @@ class UWexpression(Symbol, uw_object):
                 )
 
         try:
-            atoms = self.value.atoms()
+            atoms = self.sym.atoms()
             for atom in atoms:
-                if atom is not self.value:
+                if atom is not self.sym:
                     try:
                         atom._object_viewer(description=False, level=level + 1)
                     except AttributeError:

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -214,11 +214,8 @@ class SNES_Darcy(SNES_Scalar):
         self._setup_problem_description = self.darcy_problem_description
 
         # default values for properties
-        self._f = sympy.Matrix([[0]])
+        self._f = sympy.Matrix([0])
         self._k = 1
-
-        self._s = sympy.Matrix.zeros(rows=1, cols=self.mesh.dim).T
-        self._s[1] = -1
 
         self._constitutive_model = None
 
@@ -289,15 +286,6 @@ class SNES_Darcy(SNES_Scalar):
     def f(self, value):
         self.is_setup = False
         self._f = sympy.Matrix((value,))
-
-    @property
-    def s(self):
-        return self._s
-
-    @s.setter
-    def s(self, value):
-        self.is_setup = False
-        self._s = sympy.Matrix((value,))
 
     @property
     def darcy_flux(self):

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -120,11 +120,11 @@ class SNES_Poisson(SNES_Scalar):
     @timing.routine_timer_decorator
     def poisson_problem_description(self):
         # f1 residual term (weighted integration) - scalar function
-        self._f0 = self.F0.value
+        self._f0 = self.F0.sym
 
         # f1 residual term (integration by parts / gradients)
         # isotropic
-        self._f1 = self.F1.value
+        self._f1 = self.F1.sym
 
         return
 
@@ -217,7 +217,7 @@ class SNES_Darcy(SNES_Scalar):
         self._f = sympy.Matrix([[0]])
         self._k = 1
 
-        self._s = sympy.Matrix.zeros(rows=1, cols=self.mesh.dim)
+        self._s = sympy.Matrix.zeros(rows=1, cols=self.mesh.dim).T
         self._s[1] = -1
 
         self._constitutive_model = None
@@ -249,7 +249,7 @@ class SNES_Darcy(SNES_Scalar):
         )
 
         # backward compatibility
-        self._f0 = f0_val.value
+        self._f0 = f0_val.sym
 
         return f0_val
 
@@ -263,21 +263,21 @@ class SNES_Darcy(SNES_Scalar):
         )
 
         # backward compatibility
-        self._f1 = F1_val.value
-        self._v_projector.uw_function = -F1_val.value
+        self._f1 = F1_val.sym
+        self._v_projector.uw_function = -F1_val.sym
 
         return F1_val
 
     @timing.routine_timer_decorator
     def darcy_problem_description(self):
         # f1 residual term (weighted integration)
-        self._f0 = self.F0.value
+        self._f0 = self.F0.sym
 
         # f1 residual term (integration by parts / gradients)
-        self._f1 = self.F1.value
+        self._f1 = self.F1.sym
 
         # Flow calculation
-        self._v_projector.uw_function = -self.F1.value
+        self._v_projector.uw_function = -self.F1.sym
 
         return
 
@@ -532,13 +532,13 @@ class SNES_Stokes(SNES_Stokes_SaddlePt):
     def stokes_problem_description(self):
 
         # f0 residual term
-        self._u_f0 = self.F0.value
+        self._u_f0 = self.F0.sym
 
         # f1 residual term
-        self._u_f1 = self.F1.value
+        self._u_f1 = self.F1.sym
 
         # p0 residual term
-        self._p_f0 = self.PF0.value
+        self._p_f0 = self.PF0.sym
 
         return
 
@@ -619,7 +619,7 @@ class SNES_Stokes(SNES_Stokes_SaddlePt):
     @penalty.setter
     def penalty(self, value):
         self.is_setup = False
-        self._penalty.value = value
+        self._penalty.sym = value
 
 
 class SNES_VE_Stokes(SNES_Stokes):
@@ -770,7 +770,7 @@ class SNES_VE_Stokes(SNES_Stokes):
             order = self._order
 
         if timestep is None:
-            timestep = self.delta_t.value
+            timestep = self.delta_t.sym
 
         if timestep != self.delta_t:
             self._constitutive_model.Parameters.elastic_dt = timestep  # this will force an initialisation because the functions need to be updated
@@ -900,11 +900,11 @@ class SNES_Projection(SNES_Scalar):
         # F0 is left in place for the user to inject
         # non-linear constraints if required
 
-        self._f0 = self.F0.value
+        self._f0 = self.F0.sym
 
         # F1 is left in the users control ... e.g to add other gradient constraints to the stiffness matrix
 
-        self._f1 = self.F1.value
+        self._f1 = self.F1.sym
 
         return
 
@@ -1036,12 +1036,12 @@ class SNES_Vector_Projection(SNES_Vector):
         # F0 is left in place for the user to inject
         # non-linear constraints if required
 
-        self._f0 = self.F0.value
+        self._f0 = self.F0.sym
 
         # F1 is left in the users control ... e.g to add other gradient constraints to the stiffness matrix
 
         self._f1 = (
-            self.F1.value
+            self.F1.sym
             + self.smoothing * self.Unknowns.E
             + self.penalty
             * self.mesh.vector.divergence(self.u.sym)
@@ -1391,10 +1391,10 @@ class SNES_AdvectionDiffusion(SNES_Scalar):
 
     def adv_diff_slcn_problem_description(self):
         # f0 residual term
-        self._f0 = self.F0.value
+        self._f0 = self.F0.sym
 
         # f1 residual term
-        self._f1 = self.F1.value
+        self._f1 = self.F1.sym
 
         return
 
@@ -1418,7 +1418,7 @@ class SNES_AdvectionDiffusion(SNES_Scalar):
     @delta_t.setter
     def delta_t(self, value):
         self.is_setup = False
-        self._delta_t.value = value
+        self._delta_t.sym = value
 
     @timing.routine_timer_decorator
     def estimate_dt(self):
@@ -1763,13 +1763,13 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
     ## Deprecate this function
     def navier_stokes_problem_description(self):
         # f0 residual term
-        self._u_f0 = self.F0.value
+        self._u_f0 = self.F0.sym
 
         # f1 residual term
-        self._u_f1 = self.F1.value
+        self._u_f1 = self.F1.sym
 
         # p1 residual term
-        self._p_f0 = self.PF0.value
+        self._p_f0 = self.PF0.sym
 
         return
 
@@ -1780,7 +1780,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
     @delta_t.setter
     def delta_t(self, value):
         self.is_setup = False
-        self._delta_t.value = value
+        self._delta_t.sym = value
 
     @property
     def rho(self):
@@ -1789,7 +1789,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
     @rho.setter
     def rho(self, value):
         self.is_setup = False
-        self._rho.value = value
+        self._rho.sym = value
 
     @property
     def f(self):
@@ -1862,7 +1862,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
     @penalty.setter
     def penalty(self, value):
         self.is_setup = False
-        self._penalty.value = value
+        self._penalty.sym = value
 
     @timing.routine_timer_decorator
     def solve(

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -1410,7 +1410,7 @@ class SNES_AdvectionDiffusion(SNES_Scalar):
 
     @timing.routine_timer_decorator
     def estimate_dt(self):
-        """
+        r"""
         Calculates an appropriate timestep for the given
         mesh and diffusivity configuration. This is an implicit solver
         so the $\delta_t$ should be interpreted as:
@@ -1920,7 +1920,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
 
     @timing.routine_timer_decorator
     def estimate_dt(self):
-        """
+        r"""
         Calculates an appropriate timestep for the given
         mesh and viscosity configuration. This is an implicit solver
         so the $\delta_t$ should be interpreted as:

--- a/tests/test_0504_projections.py
+++ b/tests/test_0504_projections.py
@@ -70,7 +70,7 @@ def test_vector_projection():
     vector_projection.smoothing = 1.0e-3
 
     vector_projection.add_dirichlet_bc((0.0,None), "Right")
-    vector_projection.add_dirichlet_bc(0.0, "Top", components=[1]) # old style with components
+    vector_projection.add_dirichlet_bc((None,0.0), "Top")
     vector_projection.add_dirichlet_bc((None,0.0), "Bottom")
 
     vector_projection.solve()

--- a/tests/test_1010_stokesCart.py
+++ b/tests/test_1010_stokesCart.py
@@ -157,7 +157,7 @@ def test_stokes_boxmesh_bc_failure():
         stokes.bodyforce = 1.0e6 * sympy.Matrix([0, x])
 
         stokes.add_dirichlet_bc((0.0, 0.0), "Bottom")
-        stokes.add_dirichlet_bc((0.0, 0.0), "Top", 0)
+        stokes.add_dirichlet_bc((0.0, 0.0), "Top")
 
         stokes.add_dirichlet_bc((0.0, sympy.oo), "Left")
         stokes.add_dirichlet_bc((0.0, sympy.oo), "Right")


### PR DESCRIPTION
* Renaming the UWexpressions attribute `value` to `sym`. This is aligned with all sympy objects being called `.sym`.
* Fixed up the default Darcy Solver which wasn't using the `.sym` handle correctly.
* Removed all warnings in tests by adding r-strings.
Still need to audit all the solvers and constitutive_models. To do that in another PR later this week. 