### PR TITLE
setup.py clean up for mpi4py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,19 +10,7 @@ import os
 import numpy
 import petsc4py
 
-if os.environ.get("CC") is None:
-    import warnings
-
-    warnings.warn(
-        "CC environment variable not set. Using mpi4py's compiler configuration"
-    )
-    # Get CC from mpi4py
-    import mpi4py
-
-    conf = mpi4py.get_config()
-    os.environ["CC"] = conf["mpicc"]
-
-# PETSc version check - 3.16 or higher
+# PETSc version check - 3.18 or higher
 from petsc4py import PETSc
 
 petscVer = PETSc.Sys().getVersion()
@@ -34,7 +22,6 @@ if petscVer[0] != 3 or petscVer[1] < 18:
         f"{petscVer[0]}.{petscVer[1]}.{petscVer[2]}"
     )
     raise RuntimeError(msg)
-
 
 def configure():
 


### PR DESCRIPTION
As a result of the previous PR 
https://github.com/underworldcode/underworld3/pull/243
it was found `mpi4py.get_config()` has been removed in mpi4py-4+.

So removing the check now.
