### PR TITLE
Restore .environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,1 +1,34 @@
-.binder/environment.yml
+name: uw3
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - compilers
+  - openmpi
+  - openmpi-mpicc
+  - openmpi-mpicxx
+  - petsc=3.21.5 # Fix for now (errors with hdf5 / uw3)
+  - petsc4py=3.21.5
+  - cython=3.*
+  - mpmath<=1.3
+  - mesalib
+  - numpy
+  - scipy
+  - mpi4py
+  - h5py
+  - sympy
+  - pytest
+  - ipython
+  - pyvista
+  - pip
+  # gmsh dependencies (prefer not to use apt.txt)
+  - xorg-libxft
+  - xorg-libxinerama
+  - pip:
+      - gmsh
+      - gmsh-api
+      - jupyterlab
+      - jupytext
+      - pygments
+      - trame-vtk
+      - trame-vuetify


### PR DESCRIPTION
The environment.yml file was link to the one in the obsolete .binder folder that we removed when we moved to a separate launch repository (for efficiency reasons) but we do need the file so ... it's back.